### PR TITLE
fix: add google provider to string matching

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -72,6 +72,7 @@ impl std::str::FromStr for LLMBackend {
             "deepseek" => Ok(LLMBackend::DeepSeek),
             "xai" => Ok(LLMBackend::XAI),
             "phind" => Ok(LLMBackend::Phind),
+            "google" => Ok(LLMBackend::Google),
             "groq" => Ok(LLMBackend::Groq),
             _ => Err(LLMError::InvalidRequest(format!(
                 "Unknown LLM backend: {}",


### PR DESCRIPTION
Noticed that the `from_str` match was missing a match for the google backend. Thanks for the useful crate!