### PR TITLE
Add support for structured output requests

### DIFF
--- a/examples/google_structured_output_example.rs
+++ b/examples/google_structured_output_example.rs
@@ -1,0 +1,60 @@
+// Import required modules from the LLM library for Google Gemini integration
+use llm::{
+    builder::{LLMBackend, LLMBuilder}, // Builder pattern components
+    chat::ChatMessage,                 // Chat-related structures
+};
+use serde_json::Value;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Get Google API key from environment variable or use test key as fallback
+    let api_key = std::env::var("GOOGLE_API_KEY").unwrap_or("google-key".into());
+
+    // Define a simple JSON schema for structured output
+    let schema = r#"
+        {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "age": {
+                    "type": "integer"
+                },
+                "is_student": {
+                    "type": "boolean"
+                }
+            },
+            "required": ["name", "age", "is_student"]
+        }
+    "#;
+    let schema: Value = serde_json::from_str(schema)?;
+
+    // Initialize and configure the LLM client
+    let llm = LLMBuilder::new()
+        .backend(LLMBackend::Google) // Use Google as the LLM provider
+        .api_key(api_key) // Set the API key
+        .model("gemini-2.0-flash-exp") // Use Gemini Pro model
+        .max_tokens(8512) // Limit response length
+        .temperature(0.7) // Control response randomness (0.0-1.0)
+        .stream(false) // Disable streaming responses
+        // Optional: Set system prompt
+        .system("You are a helpful AI assistant. Please generate a random student using the provided JSON schema.")
+        // Set JSON schema for structured output
+        .schema(schema)
+        .build()
+        .expect("Failed to build LLM (Google)");
+
+    // Prepare conversation history with example messages
+    let messages = vec![ChatMessage::user()
+        .content("Please generate a random student using the provided JSON schema.")
+        .build()];
+
+    // Send chat request and handle the response
+    match llm.chat(&messages).await {
+        Ok(text) => println!("Google Gemini response:\n{}", text),
+        Err(e) => eprintln!("Chat error: {}", e),
+    }
+
+    Ok(())
+}

--- a/examples/ollama_structured_output_example.rs
+++ b/examples/ollama_structured_output_example.rs
@@ -1,0 +1,58 @@
+// Import required modules from the LLM library
+use llm::{
+    builder::{LLMBackend, LLMBuilder},
+    chat::ChatMessage,
+};
+use serde_json::Value;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Get Ollama server URL from environment variable or use default localhost
+    let base_url = std::env::var("OLLAMA_URL").unwrap_or("http://127.0.0.1:11434".into());
+
+    // Define a simple JSON schema for structured output
+    let schema = r#"
+        {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "age": {
+                    "type": "integer"
+                },
+                "is_student": {
+                    "type": "boolean"
+                }
+            },
+            "required": ["name", "age", "is_student"]
+        }
+    "#;
+    let schema: Value = serde_json::from_str(schema)?;
+
+    // Initialize and configure the LLM client
+    let llm = LLMBuilder::new()
+        .backend(LLMBackend::Ollama) // Use Ollama as the LLM backend
+        .base_url(base_url) // Set the Ollama server URL
+        .model("llama3.1:latest")
+        .max_tokens(1000) // Set maximum response length
+        .temperature(0.7) // Control response randomness (0.0-1.0)
+        .stream(false) // Disable streaming responses
+        .schema(schema) // Set JSON schema for structured output
+        .system("You are a helpful AI assistant. Please generate a random student using the provided JSON schema.")
+        .build()
+        .expect("Failed to build LLM (Ollama)");
+
+    // Prepare conversation history with example messages
+    let messages = vec![ChatMessage::user()
+        .content("Please generate a random student using the provided JSON schema.")
+        .build()];
+
+    // Send chat request and handle the response
+    match llm.chat(&messages).await {
+        Ok(text) => println!("Ollama chat response:\n{}", text),
+        Err(e) => eprintln!("Chat error: {}", e),
+    }
+
+    Ok(())
+}

--- a/examples/openai_structured_output_example.rs
+++ b/examples/openai_structured_output_example.rs
@@ -1,0 +1,63 @@
+// Import required modules from the LLM library for OpenAI integration
+use llm::{
+    builder::{LLMBackend, LLMBuilder}, // Builder pattern components
+    chat::ChatMessage,                 // Chat-related structures
+};
+use serde_json::Value;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Get OpenAI API key from environment variable or use test key as fallback
+    let api_key = std::env::var("OPENAI_API_KEY").unwrap_or("sk-TESTKEY".into());
+
+    // Define a simple JSON schema for structured output
+    let schema = r#"
+        {
+            "name": "Student",
+            "schema": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "age": {
+                    "type": "integer"
+                },
+                "is_student": {
+                    "type": "boolean"
+                }
+            },
+            "required": ["name", "age", "is_student"],
+            "additionalProperties": false
+}
+        }
+    "#;
+
+    let schema: Value = serde_json::from_str(schema)?;
+
+    // Initialize and configure the LLM client
+    let llm = LLMBuilder::new()
+        .backend(LLMBackend::OpenAI) // Use OpenAI as the LLM provider
+        .api_key(api_key) // Set the API key
+        .model("gpt-4o") // Use GPT-4o model
+        .max_tokens(512) // Limit response length
+        .temperature(0.7) // Control response randomness (0.0-1.0)
+        .stream(false) // Disable streaming responses
+        .system("You are an AI assistant that can provide structured output to generate random students as example data. Respond in JSON format using the provided JSON schema.") // Set system description
+        .schema(schema) // Set JSON schema for structured output
+        .build()
+        .expect("Failed to build LLM (OpenAI)");
+
+    // Prepare conversation history with example messages
+    let messages = vec![ChatMessage::user()
+        .content("Generate a random student")
+        .build()];
+
+    // Send chat request and handle the response
+    match llm.chat(&messages).await {
+        Ok(text) => println!("Chat response:\n{}", text),
+        Err(e) => eprintln!("Chat error: {}", e),
+    }
+
+    Ok(())
+}

--- a/examples/openai_structured_output_example.rs
+++ b/examples/openai_structured_output_example.rs
@@ -10,7 +10,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Get OpenAI API key from environment variable or use test key as fallback
     let api_key = std::env::var("OPENAI_API_KEY").unwrap_or("sk-TESTKEY".into());
 
-    // Define a simple JSON schema for structured output
+    // Define a simple JSON schema for structured output.
+    // Note that the schema has some [odd requirements](https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat&lang=curl#supported-schemas) for OpenAI. Make sure the provided schema is compatible with OpenAI's requirements.
     let schema = r#"
         {
             "name": "Student",

--- a/examples/xai_structured_output_example.rs
+++ b/examples/xai_structured_output_example.rs
@@ -1,0 +1,66 @@
+// Import required modules from the LLM library for xAI integration
+use llm::{
+    builder::{LLMBackend, LLMBuilder}, // Builder pattern components
+    chat::ChatMessage,                 // Chat-related structures
+};
+use serde_json::Value;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Get xAI API key from environment variable or use test key as fallback
+    let api_key = std::env::var("XAI_API_KEY").unwrap_or("sk-TESTKEY".into());
+
+    // Define a simple JSON schema for structured output
+    // For XAI, the schema must be provided in the property "schema"
+    let schema = r#"
+{
+    "name": "Student",
+    "schema": {
+        "properties": {
+            "age": {
+                "type": "integer"
+            },
+            "is_student": {
+                "type": "boolean"
+            },
+            "name": {
+                "type": "string"
+            }
+        },
+        "required": [
+            "name",
+            "age",
+            "is_student"
+        ],
+        "type": "object"
+    }
+}
+    "#;
+    let schema: Value = serde_json::from_str(schema)?;
+
+    // Initialize and configure the LLM client
+    let llm = LLMBuilder::new()
+        .backend(LLMBackend::XAI) // Use xAI as the LLM provider
+        .api_key(api_key) // Set the API key
+        .model("grok-2-latest") // Use Grok-2 model
+        .max_tokens(512) // Limit response length
+        .temperature(0.7) // Control response randomness (0.0-1.0)
+        .stream(false) // Disable streaming responses
+        .system("You are a helpful AI assistant. Please generate a random student using the provided JSON schema.")
+        .schema(schema) // Set JSON schema for structured output
+        .build()
+        .expect("Failed to build LLM (xAI)");
+
+    // Prepare conversation history with example messages
+    let messages = vec![ChatMessage::user()
+        .content("Please generate a random student using the provided JSON schema.")
+        .build()];
+
+    // Send chat request and handle the response
+    match llm.chat(&messages).await {
+        Ok(text) => println!("Chat response:\n{}", text),
+        Err(e) => eprintln!("Chat error: {}", e),
+    }
+
+    Ok(())
+}

--- a/src/backends/openai.rs
+++ b/src/backends/openai.rs
@@ -217,6 +217,7 @@ impl OpenAI {
     /// * `timeout_seconds` - Request timeout in seconds
     /// * `system` - System prompt
     /// * `stream` - Whether to stream responses
+    /// * `json_schema` - JSON schema for structured output
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         api_key: impl Into<String>,
@@ -336,7 +337,7 @@ impl ChatProvider for OpenAI {
 
         // OpenAI's structured output has some [odd requirements](https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat&lang=curl#supported-schemas).
         // There's currently no check for these, so we'll leave it up to the user to provide a valid schema.
-        let schema: Option<OpenAIResponseFormat> =
+        let response_format: Option<OpenAIResponseFormat> =
             self.json_schema.as_ref().map(|s| OpenAIResponseFormat {
                 response_type: OpenAIResponseType::JsonSchema,
                 json_schema: Some(s.clone()),
@@ -352,7 +353,7 @@ impl ChatProvider for OpenAI {
             top_k: self.top_k,
             tools: tools.map(|t| t.to_vec()),
             reasoning_effort: self.reasoning_effort.clone(),
-            response_format: schema,
+            response_format,
         };
 
         let mut request = self

--- a/src/backends/openai.rs
+++ b/src/backends/openai.rs
@@ -16,6 +16,7 @@ use async_trait::async_trait;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 /// Client for interacting with OpenAI's API.
 ///
@@ -35,6 +36,8 @@ pub struct OpenAI {
     pub embedding_encoding_format: Option<String>,
     pub embedding_dimensions: Option<u32>,
     pub reasoning_effort: Option<String>,
+    /// JSON schema for structured output
+    pub json_schema: Option<Value>,
     client: Client,
 }
 
@@ -74,7 +77,7 @@ struct OpenAIEmbeddingRequest {
 }
 
 /// Request payload for OpenAI's chat API endpoint.
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 struct OpenAIChatRequest<'a> {
     model: &'a str,
     messages: Vec<OpenAIChatMessage<'a>>,
@@ -91,6 +94,8 @@ struct OpenAIChatRequest<'a> {
     tools: Option<Vec<Tool>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     reasoning_effort: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    response_format: Option<OpenAIResponseFormat>,
 }
 
 impl std::fmt::Display for ToolCall {
@@ -141,6 +146,27 @@ struct OpenAIEmbeddingData {
 #[derive(Deserialize, Debug)]
 struct OpenAIEmbeddingResponse {
     data: Vec<OpenAIEmbeddingData>,
+}
+
+/// An object specifying the format that the model must output.
+///Setting to `{ "type": "json_schema", "json_schema": {...} }` enables Structured Outputs which ensures the model will match your supplied JSON schema. Learn more in the [Structured Outputs guide](https://platform.openai.com/docs/guides/structured-outputs).
+/// Setting to `{ "type": "json_object" }` enables the older JSON mode, which ensures the message the model generates is valid JSON. Using `json_schema` is preferred for models that support it.
+#[derive(Deserialize, Debug, Serialize)]
+enum OpenAIResponseType {
+    #[serde(rename = "text")]
+    Text,
+    #[serde(rename = "json_schema")]
+    JsonSchema,
+    #[serde(rename = "json_object")]
+    JsonObject,
+}
+
+#[derive(Deserialize, Debug, Serialize)]
+struct OpenAIResponseFormat {
+    #[serde(rename = "type")]
+    response_type: OpenAIResponseType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    json_schema: Option<Value>,
 }
 
 impl ChatResponse for OpenAIChatResponse {
@@ -206,6 +232,7 @@ impl OpenAI {
         embedding_dimensions: Option<u32>,
         tools: Option<Vec<Tool>>,
         reasoning_effort: Option<String>,
+        json_schema: Option<Value>,
     ) -> Self {
         let mut builder = Client::builder();
         if let Some(sec) = timeout_seconds {
@@ -226,6 +253,7 @@ impl OpenAI {
             embedding_dimensions,
             client: builder.build().expect("Failed to build reqwest Client"),
             reasoning_effort,
+            json_schema,
         }
     }
 }
@@ -306,6 +334,14 @@ impl ChatProvider for OpenAI {
             );
         }
 
+        // OpenAI's structured output has some [odd requirements](https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat&lang=curl#supported-schemas).
+        // There's currently no check for these, so we'll leave it up to the user to provide a valid schema.
+        let schema: Option<OpenAIResponseFormat> =
+            self.json_schema.as_ref().map(|s| OpenAIResponseFormat {
+                response_type: OpenAIResponseType::JsonSchema,
+                json_schema: Some(s.clone()),
+            });
+
         let body = OpenAIChatRequest {
             model: &self.model,
             messages: openai_msgs,
@@ -316,6 +352,7 @@ impl ChatProvider for OpenAI {
             top_k: self.top_k,
             tools: tools.map(|t| t.to_vec()),
             reasoning_effort: self.reasoning_effort.clone(),
+            response_format: schema,
         };
 
         let mut request = self

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -372,6 +372,7 @@ impl LLMBuilder {
                         self.stream,
                         self.top_p,
                         self.top_k,
+                        self.json_schema,
                     );
                     Box::new(ollama)
                 }
@@ -425,6 +426,7 @@ impl LLMBuilder {
                         self.top_k,
                         self.embedding_encoding_format,
                         self.embedding_dimensions,
+                        self.json_schema,
                     );
                     Box::new(xai)
                 }
@@ -472,6 +474,7 @@ impl LLMBuilder {
                         self.stream,
                         self.top_p,
                         self.top_k,
+                        self.json_schema,
                     );
                     Box::new(google)
                 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -3,6 +3,8 @@
 //! This module provides a flexible builder pattern for creating and configuring
 //! LLM (Large Language Model) provider instances with various settings and options.
 
+use serde_json::Value;
+
 use crate::{
     chat::{FunctionTool, ParameterProperty, ParametersSchema, ReasoningEffort, Tool},
     error::LLMError,
@@ -74,7 +76,9 @@ impl std::str::FromStr for LLMBackend {
             "phind" => Ok(LLMBackend::Phind),
             "google" => Ok(LLMBackend::Google),
             "groq" => Ok(LLMBackend::Groq),
-            _ => Err(LLMError::InvalidRequest(format!("Unknown LLM backend: {s}")))
+            _ => Err(LLMError::InvalidRequest(format!(
+                "Unknown LLM backend: {s}"
+            ))),
         }
     }
 }
@@ -123,6 +127,8 @@ pub struct LLMBuilder {
     reasoning_effort: Option<String>,
     /// reasoning_budget_tokens
     reasoning_budget_tokens: Option<u32>,
+    /// JSON schema for structured output
+    json_schema: Option<Value>,
 }
 
 impl LLMBuilder {
@@ -230,6 +236,12 @@ impl LLMBuilder {
         self
     }
 
+    /// Sets the JSON schema for structured output.
+    pub fn schema(mut self, schema: impl Into<Value>) -> Self {
+        self.json_schema = Some(schema.into());
+        self
+    }
+
     /// Sets a validation function to verify LLM responses.
     ///
     /// # Arguments
@@ -304,6 +316,7 @@ impl LLMBuilder {
                         self.embedding_dimensions,
                         self.tools,
                         self.reasoning_effort,
+                        self.json_schema,
                     ))
                 }
             }


### PR DESCRIPTION
Adds framework for structured output requests as suggested in #22. Includes implementations for Google, Ollama, OpenAI, and XAI.
The schema formats for each of these vary, as you can see in the examples, so that's not ideal. Might need to include cleaning tools to prepare a schema for each different provider, but that can also be added later.