### PR TITLE
feat: add base_url to openai provider

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -304,6 +304,7 @@ impl LLMBuilder {
                     })?;
                     Box::new(crate::backends::openai::OpenAI::new(
                         key,
+                        self.base_url,
                         self.model,
                         self.max_tokens,
                         self.temperature,


### PR DESCRIPTION
Add base_url as a optional option for the OpenAI provider. I did thid to be able to connect to OpenAI compatible endpoint (namely OpenRouter in my case)

I hope it may help others