### PR TITLE
Refactor structured response API to use a struct input instead of Value

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ With a **unified API** and **builder style** - similar to the Stripe experience 
 - **REST API**: Serve any LLM backend as a REST API with openai standard format.
 - **Vision**: Add vision to your requests to use images in your LLMs.
 - **Reasoning**: Add reasoning to your requests to use reasoning in your LLMs.
+- **Structured Output**: Request structured output from certain LLM providers based on a provided JSON schema.
 
 ## Use any LLM backend on your project
 

--- a/examples/google_structured_output_example.rs
+++ b/examples/google_structured_output_example.rs
@@ -1,9 +1,8 @@
 // Import required modules from the LLM library for Google Gemini integration
 use llm::{
-    builder::{LLMBackend, LLMBuilder}, // Builder pattern components
-    chat::ChatMessage,                 // Chat-related structures
+    builder::{LLMBackend, LLMBuilder},
+    chat::{ChatMessage, StructuredOutputFormat},
 };
-use serde_json::Value;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -13,22 +12,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Define a simple JSON schema for structured output
     let schema = r#"
         {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string"
+            "name": "student",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "age": {
+                        "type": "integer"
+                    },
+                    "is_student": {
+                        "type": "boolean"
+                    }
                 },
-                "age": {
-                    "type": "integer"
-                },
-                "is_student": {
-                    "type": "boolean"
-                }
-            },
-            "required": ["name", "age", "is_student"]
+                "required": ["name", "age", "is_student"]
+            }
         }
     "#;
-    let schema: Value = serde_json::from_str(schema)?;
+    let schema: StructuredOutputFormat = serde_json::from_str(schema)?;
 
     // Initialize and configure the LLM client
     let llm = LLMBuilder::new()

--- a/examples/multi_backend_structured_output_example.rs
+++ b/examples/multi_backend_structured_output_example.rs
@@ -1,0 +1,73 @@
+//! Send the same JSON schema to multiple backends for structured output.
+
+use llm::{
+    builder::{LLMBackend, LLMBuilder},
+    chat::{ChatMessage, StructuredOutputFormat},
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = std::env::var("OPENAI_API_KEY").unwrap_or("sk-TESTKEY".into());
+
+    let schema = r#"
+    {
+        "name": "Student",
+        "schema": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "age": {
+                    "type": "integer"
+                },
+                "is_student": {
+                    "type": "boolean"
+                }
+            },
+            "required": ["name", "age", "is_student"]
+        }
+    }
+"#;
+    let schema: StructuredOutputFormat = serde_json::from_str(schema)?;
+
+    let messages = vec![ChatMessage::user()
+        .content("Generate a random student")
+        .build()];
+
+    let llm_openai = LLMBuilder::new()
+        .backend(LLMBackend::OpenAI)
+        .api_key(api_key)
+        .model("gpt-4o")
+        .max_tokens(512)
+        .temperature(0.7)
+        .stream(false)
+        .system("You are an AI assistant that can provide structured output to generate random students as example data. Respond in JSON format using the provided JSON schema.")
+        .schema(schema.clone())
+        .build()
+        .expect("Failed to build LLM (OpenAI)");
+
+    match llm_openai.chat(&messages).await {
+        Ok(text) => println!("Chat response:\n{}", text),
+        Err(e) => eprintln!("Chat error: {}", e),
+    }
+
+    let llm_ollama = LLMBuilder::new()
+        .backend(LLMBackend::Ollama)
+        .base_url("http://127.0.0.1:11434")
+        .model("llama3.1:latest")
+        .max_tokens(512)
+        .temperature(0.7)
+        .stream(false)
+        .schema(schema)
+        .system("You are a helpful AI assistant. Please generate a random student using the provided JSON schema.")
+        .build()
+        .expect("Failed to build LLM (Ollama)");
+
+    match llm_ollama.chat(&messages).await {
+        Ok(text) => println!("Ollama chat response:\n{}", text),
+        Err(e) => eprintln!("Chat error: {}", e),
+    }
+
+    Ok(())
+}

--- a/examples/ollama_structured_output_example.rs
+++ b/examples/ollama_structured_output_example.rs
@@ -1,9 +1,8 @@
 // Import required modules from the LLM library
 use llm::{
     builder::{LLMBackend, LLMBuilder},
-    chat::ChatMessage,
+    chat::{ChatMessage, StructuredOutputFormat},
 };
-use serde_json::Value;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -13,22 +12,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Define a simple JSON schema for structured output
     let schema = r#"
         {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string"
+            "name": "student",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "age": {
+                        "type": "integer"
+                    },
+                    "is_student": {
+                        "type": "boolean"
+                    }
                 },
-                "age": {
-                    "type": "integer"
-                },
-                "is_student": {
-                    "type": "boolean"
-                }
-            },
-            "required": ["name", "age", "is_student"]
+                "required": ["name", "age", "is_student"]
+            }
         }
     "#;
-    let schema: Value = serde_json::from_str(schema)?;
+    let schema: StructuredOutputFormat = serde_json::from_str(schema)?;
 
     // Initialize and configure the LLM client
     let llm = LLMBuilder::new()

--- a/examples/openai_structured_output_example.rs
+++ b/examples/openai_structured_output_example.rs
@@ -1,40 +1,36 @@
 // Import required modules from the LLM library for OpenAI integration
 use llm::{
     builder::{LLMBackend, LLMBuilder}, // Builder pattern components
-    chat::ChatMessage,                 // Chat-related structures
+    chat::{ChatMessage, StructuredOutputFormat}, // Chat-related structures
 };
-use serde_json::Value;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Get OpenAI API key from environment variable or use test key as fallback
     let api_key = std::env::var("OPENAI_API_KEY").unwrap_or("sk-TESTKEY".into());
 
-    // Define a simple JSON schema for structured output.
-    // Note that the schema has some [odd requirements](https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat&lang=curl#supported-schemas) for OpenAI. Make sure the provided schema is compatible with OpenAI's requirements.
+    // Define a simple JSON schema for structured output
     let schema = r#"
         {
-            "name": "Student",
+            "name": "student",
             "schema": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string"
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "age": {
+                        "type": "integer"
+                    },
+                    "is_student": {
+                        "type": "boolean"
+                    }
                 },
-                "age": {
-                    "type": "integer"
-                },
-                "is_student": {
-                    "type": "boolean"
-                }
-            },
-            "required": ["name", "age", "is_student"],
-            "additionalProperties": false
-}
+                "required": ["name", "age", "is_student"]
+            }
         }
     "#;
-
-    let schema: Value = serde_json::from_str(schema)?;
+    let schema: StructuredOutputFormat = serde_json::from_str(schema)?;
 
     // Initialize and configure the LLM client
     let llm = LLMBuilder::new()

--- a/examples/xai_structured_output_example.rs
+++ b/examples/xai_structured_output_example.rs
@@ -1,9 +1,8 @@
 // Import required modules from the LLM library for xAI integration
 use llm::{
     builder::{LLMBackend, LLMBuilder}, // Builder pattern components
-    chat::ChatMessage,                 // Chat-related structures
+    chat::{ChatMessage, StructuredOutputFormat}, // Chat-related structures
 };
-use serde_json::Value;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -11,32 +10,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key = std::env::var("XAI_API_KEY").unwrap_or("sk-TESTKEY".into());
 
     // Define a simple JSON schema for structured output
-    // For XAI, the schema must be provided in the property "schema"
     let schema = r#"
-{
-    "name": "Student",
-    "schema": {
-        "properties": {
-            "age": {
-                "type": "integer"
-            },
-            "is_student": {
-                "type": "boolean"
-            },
-            "name": {
-                "type": "string"
+        {
+            "name": "student",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "age": {
+                        "type": "integer"
+                    },
+                    "is_student": {
+                        "type": "boolean"
+                    }
+                },
+                "required": ["name", "age", "is_student"]
             }
-        },
-        "required": [
-            "name",
-            "age",
-            "is_student"
-        ],
-        "type": "object"
-    }
-}
+        }
     "#;
-    let schema: Value = serde_json::from_str(schema)?;
+    let schema: StructuredOutputFormat = serde_json::from_str(schema)?;
 
     // Initialize and configure the LLM client
     let llm = LLMBuilder::new()

--- a/src/backends/google.rs
+++ b/src/backends/google.rs
@@ -42,7 +42,10 @@
 //! ```
 
 use crate::{
-    chat::{ChatMessage, ChatProvider, ChatResponse, ChatRole, MessageType, Tool},
+    chat::{
+        ChatMessage, ChatProvider, ChatResponse, ChatRole, MessageType, StructuredOutputFormat,
+        Tool,
+    },
     completion::{CompletionProvider, CompletionRequest, CompletionResponse},
     embedding::EmbeddingProvider,
     error::LLMError,
@@ -78,7 +81,7 @@ pub struct Google {
     /// Top-k sampling parameter
     pub top_k: Option<u32>,
     /// JSON schema for structured output
-    pub json_schema: Option<Value>,
+    pub json_schema: Option<StructuredOutputFormat>,
     /// Available tools for function calling
     pub tools: Option<Vec<Tool>>,
     /// HTTP client for making API requests
@@ -415,7 +418,7 @@ impl Google {
         stream: Option<bool>,
         top_p: Option<f32>,
         top_k: Option<u32>,
-        json_schema: Option<Value>,
+        json_schema: Option<StructuredOutputFormat>,
         tools: Option<Vec<Tool>>,
     ) -> Self {
         let mut builder = Client::builder();
@@ -532,12 +535,25 @@ impl ChatProvider for Google {
         {
             None
         } else {
-            // If json_schema is present, use it as the response schema and set response_mime_type to JSON
-            let response_mime_type: Option<GoogleResponseMimeType> = self
-                .json_schema
-                .as_ref()
-                .map(|_| GoogleResponseMimeType::Json);
-            let response_schema: Option<Value> = self.json_schema.clone();
+            // If json_schema and json_schema.schema are not None, use json_schema.schema as the response schema and set response_mime_type to JSON
+            // Google's API doesn't need the schema to have a "name" field, so we can just use the schema directly.
+            let (response_mime_type, response_schema) = if let Some(json_schema) = &self.json_schema
+            {
+                if let Some(schema) = &json_schema.schema {
+                    // If the schema has an "additionalProperties" field (as required by OpenAI), remove it as Google's API doesn't support it
+                    let mut schema = schema.clone();
+
+                    if let Some(obj) = schema.as_object_mut() {
+                        obj.remove("additionalProperties");
+                    }
+
+                    (Some(GoogleResponseMimeType::Json), Some(schema))
+                } else {
+                    (None, None)
+                }
+            } else {
+                (None, None)
+            };
 
             Some(GoogleGenerationConfig {
                 max_output_tokens: self.max_tokens,
@@ -684,12 +700,25 @@ impl ChatProvider for Google {
 
         // Build generation config
         let generation_config = {
-            // If json_schema is present, use it as the response schema and set response_mime_type to JSON
-            let response_mime_type: Option<GoogleResponseMimeType> = self
-                .json_schema
-                .as_ref()
-                .map(|_| GoogleResponseMimeType::Json);
-            let response_schema: Option<Value> = self.json_schema.clone();
+            // If json_schema and json_schema.schema are not None, use json_schema.schema as the response schema and set response_mime_type to JSON
+            // Google's API doesn't need the schema to have a "name" field, so we can just use the schema directly.
+            let (response_mime_type, response_schema) = if let Some(json_schema) = &self.json_schema
+            {
+                if let Some(schema) = &json_schema.schema {
+                    // If the schema has an "additionalProperties" field (as required by OpenAI), remove it as Google's API doesn't support it
+                    let mut schema = schema.clone();
+
+                    if let Some(obj) = schema.as_object_mut() {
+                        obj.remove("additionalProperties");
+                    }
+
+                    (Some(GoogleResponseMimeType::Json), Some(schema))
+                } else {
+                    (None, None)
+                }
+            } else {
+                (None, None)
+            };
 
             Some(GoogleGenerationConfig {
                 max_output_tokens: self.max_tokens,

--- a/src/backends/xai.rs
+++ b/src/backends/xai.rs
@@ -5,7 +5,7 @@
 
 #[cfg(feature = "xai")]
 use crate::{
-    chat::{ChatMessage, ChatProvider, ChatRole},
+    chat::{ChatMessage, ChatProvider, ChatRole, StructuredOutputFormat},
     completion::{CompletionProvider, CompletionRequest, CompletionResponse},
     embedding::EmbeddingProvider,
     error::LLMError,
@@ -18,7 +18,6 @@ use crate::{
 use async_trait::async_trait;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 /// Client for interacting with X.AI's API.
 ///
@@ -48,7 +47,7 @@ pub struct XAI {
     /// Embedding dimensions
     pub embedding_dimensions: Option<u32>,
     /// JSON schema for structured output
-    pub json_schema: Option<Value>,
+    pub json_schema: Option<StructuredOutputFormat>,
     /// HTTP client for making API requests
     client: Client,
 }
@@ -162,7 +161,7 @@ struct XAIResponseFormat {
     #[serde(rename = "type")]
     response_type: XAIResponseType,
     #[serde(skip_serializing_if = "Option::is_none")]
-    json_schema: Option<Value>,
+    json_schema: Option<StructuredOutputFormat>,
 }
 
 impl XAI {
@@ -197,7 +196,7 @@ impl XAI {
         top_k: Option<u32>,
         embedding_encoding_format: Option<String>,
         embedding_dimensions: Option<u32>,
-        json_schema: Option<Value>,
+        json_schema: Option<StructuredOutputFormat>,
     ) -> Self {
         let mut builder = Client::builder();
         if let Some(sec) = timeout_seconds {
@@ -277,7 +276,6 @@ impl ChatProvider for XAI {
             top_k: self.top_k,
             response_format,
         };
-
 
         let mut request = self
             .client

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -3,10 +3,11 @@
 //! This module provides a flexible builder pattern for creating and configuring
 //! LLM (Large Language Model) provider instances with various settings and options.
 
-use serde_json::Value;
-
 use crate::{
-    chat::{FunctionTool, ParameterProperty, ParametersSchema, ReasoningEffort, Tool, ToolChoice},
+    chat::{
+        FunctionTool, ParameterProperty, ParametersSchema, ReasoningEffort, StructuredOutputFormat,
+        Tool, ToolChoice,
+    },
     error::LLMError,
     LLMProvider,
 };
@@ -132,7 +133,7 @@ pub struct LLMBuilder {
     /// reasoning_budget_tokens
     reasoning_budget_tokens: Option<u32>,
     /// JSON schema for structured output
-    json_schema: Option<Value>,
+    json_schema: Option<StructuredOutputFormat>,
 }
 
 impl LLMBuilder {
@@ -241,7 +242,7 @@ impl LLMBuilder {
     }
 
     /// Sets the JSON schema for structured output.
-    pub fn schema(mut self, schema: impl Into<Value>) -> Self {
+    pub fn schema(mut self, schema: impl Into<StructuredOutputFormat>) -> Self {
         self.json_schema = Some(schema.into());
         self
     }


### PR DESCRIPTION
The previous implementation for defining structured output schemas used a generic `serde_json::Value` and relied on the user to properly format their schemas. This new implementation defines response formats in a struct which should make it easier to handle on each backend. An example of the utility for this is shown in `src/backends/openai.rs`, line 214, where it's now possible to add properties required by some backends.

This is a breaking change, but I doubt anyone has implemented this feature already besides myself.