### PR TITLE
Reactive memory + conditional triggers

### DIFF
--- a/examples/reactive_agent_example.rs
+++ b/examples/reactive_agent_example.rs
@@ -1,0 +1,56 @@
+// Memory sharing example
+use llm::{
+    builder::{LLMBackend, LLMBuilder},
+    chat::ChatMessage,
+    memory::{MessageCondition, SharedMemory, SlidingWindowMemory},
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let shared_memory = SharedMemory::new_reactive(SlidingWindowMemory::new(10));
+
+    let proposer = LLMBuilder::new()
+        .backend(LLMBackend::OpenAI)
+        .api_key(std::env::var("OPENAI_API_KEY").unwrap_or("sk-TESTKEY".into()))
+        .model("gpt-3.5-turbo")
+        .role("assistant")
+        .on_message_from_with_trigger("reviewer", MessageCondition::Contains("REJECT".to_string()))
+        .system("You are a proposer agent. Answer user questions accurately and concisely. When you receive REJECT from a reviewer, correct your previous response.")
+        .memory(shared_memory.clone())
+        .build()?;
+
+    let _ = LLMBuilder::new()
+        .backend(LLMBackend::Anthropic)
+        .api_key(std::env::var("ANTHROPIC_API_KEY").unwrap_or("anthro-key".into()))
+        .model("claude-sonnet-4-20250514")
+        .role("reviewer")
+        .system("You are a reviewer. Your ONLY job is to check if the assistant's answer is correct. Do NOT solve the problem yourself. Just evaluate the assistant's response and reply with ONLY the word ACCEPT (if correct) or REJECT (if wrong). Nothing else.")
+        .on_message_from("assistant")
+        .max_tokens(512)
+        .temperature(0.7)
+        .memory(shared_memory.clone())
+        .build()?;
+
+    let _ = LLMBuilder::new()
+        .backend(LLMBackend::OpenAI)
+        .api_key(std::env::var("OPENAI_API_KEY").unwrap_or("sk-TESTKEY".into()))
+        .model("gpt-4o")
+        .role("resumer")
+        .on_message_from_with_trigger("reviewer", MessageCondition::NotContains("REJECT".to_string()))
+        .on_message_from_with_trigger("reviewer", MessageCondition::Eq("ACCEPT".to_string()))
+        .system("You are a resumer agent. Summarize the conversation between the proposer and the reviewer.")
+        .memory(shared_memory.clone())
+        .build()?;
+
+    let task = ChatMessage::user()
+        .content("how much R in the word strawberry ?")
+        .build();
+    _ = proposer.chat(&[task]).await;
+
+    let mut receiver = shared_memory.subscribe();
+    while let Ok(evt) = receiver.recv().await {
+        println!("{} said: {}", evt.role, evt.msg.content);
+    }
+
+    Ok(())
+}

--- a/examples/trim_strategy_example.rs
+++ b/examples/trim_strategy_example.rs
@@ -14,18 +14,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build()?;
 
     println!("Testing TrimStrategy::Summarize with window size 3");
-    
+
     let messages = vec![
-        ChatMessage::user().content("Hello, my name is Alice").build(),
-        ChatMessage::user().content("I love programming in Rust").build(),
-        ChatMessage::user().content("What's the weather like?").build(),
+        ChatMessage::user()
+            .content("Hello, my name is Alice")
+            .build(),
+        ChatMessage::user()
+            .content("I love programming in Rust")
+            .build(),
+        ChatMessage::user()
+            .content("What's the weather like?")
+            .build(),
         ChatMessage::user().content("Tell me about AI").build(),
     ];
 
     for (i, message) in messages.iter().enumerate() {
         println!("\n--- Message {} ---", i + 1);
         println!("Sending: {}", message.content);
-        
+
         match llm.chat(&[message.clone()]).await {
             Ok(response) => println!("Response: {}", response),
             Err(e) => eprintln!("Error: {}", e),

--- a/src/chat/mod.rs
+++ b/src/chat/mod.rs
@@ -273,18 +273,14 @@ pub trait ChatProvider: Sync + Send {
         None
     }
 
-    
     /// Summarizes a conversation history into a concise 2-3 sentence summary
-    /// 
+    ///
     /// # Arguments
     /// * `msgs` - The conversation messages to summarize
     ///
     /// # Returns
     /// A string containing the summary or an error if summarization fails
-    async fn summarize_history(
-        &self,
-        msgs: &[ChatMessage],
-    ) -> Result<String, LLMError> {
+    async fn summarize_history(&self, msgs: &[ChatMessage]) -> Result<String, LLMError> {
         let prompt = format!(
             "Summarize in 2-3 sentences:\n{}",
             msgs.iter()
@@ -293,7 +289,8 @@ pub trait ChatProvider: Sync + Send {
                 .join("\n"),
         );
         let req = [ChatMessage::user().content(prompt).build()];
-        self.chat(&req).await?
+        self.chat(&req)
+            .await?
             .text()
             .ok_or(LLMError::Generic("no text in summary response".into()))
     }

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -7,8 +7,59 @@
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::broadcast;
 
 use crate::{chat::ChatMessage, error::LLMError};
+
+/// Event emitted when a message is added to reactive memory
+#[derive(Debug, Clone)]
+pub struct MessageEvent {
+    /// Role of the agent that sent the message
+    pub role: String,
+    /// The chat message content
+    pub msg: ChatMessage,
+}
+
+/// Conditions for triggering reactive message handlers
+#[derive(Clone)]
+pub enum MessageCondition {
+    /// Always trigger
+    Any,
+    /// Trigger if message content equals exact string
+    Eq(String),
+    /// Trigger if message content contains substring
+    Contains(String),
+    /// Trigger if message content does not contain substring
+    NotContains(String),
+    /// Trigger if sender role matches
+    RoleIs(String),
+    /// Trigger if sender role does not match
+    RoleNot(String),
+    /// Trigger if message length is greater than specified
+    LenGt(usize),
+    /// Custom condition function
+    Custom(Arc<dyn Fn(&ChatMessage) -> bool + Send + Sync>),
+    /// Empty
+    Empty,
+}
+
+impl MessageCondition {
+    /// Check if the condition is met for the given message event
+    pub fn matches(&self, event: &MessageEvent) -> bool {
+        match self {
+            MessageCondition::Any => true,
+            MessageCondition::Eq(text) => event.msg.content == *text,
+            MessageCondition::Contains(text) => event.msg.content.contains(text),
+            MessageCondition::NotContains(text) => !event.msg.content.contains(text),
+            MessageCondition::RoleIs(role) => event.role == *role,
+            MessageCondition::RoleNot(role) => event.role != *role,
+            MessageCondition::LenGt(len) => event.msg.content.len() > *len,
+            MessageCondition::Custom(func) => func(&event.msg),
+            MessageCondition::Empty => event.msg.content.is_empty(),
+        }
+    }
+}
 
 pub mod chat_wrapper;
 pub mod shared_memory;
@@ -100,4 +151,18 @@ pub trait MemoryProvider: Send + Sync {
 
     /// Replace all messages with a summary
     fn replace_with_summary(&mut self, _summary: String) {}
+
+    /// Get a receiver for reactive events if this memory supports them
+    fn get_event_receiver(&self) -> Option<broadcast::Receiver<MessageEvent>> {
+        None
+    }
+
+    /// Remember a message with a specific role for reactive memory
+    async fn remember_with_role(
+        &mut self,
+        message: &ChatMessage,
+        _role: String,
+    ) -> Result<(), LLMError> {
+        self.remember(message).await
+    }
 }

--- a/src/memory/sliding_window.rs
+++ b/src/memory/sliding_window.rs
@@ -146,7 +146,11 @@ impl SlidingWindowMemory {
     /// * `summary` - The summary text to replace all messages with
     pub fn replace_with_summary(&mut self, summary: String) {
         self.messages.clear();
-        self.messages.push_back(crate::chat::ChatMessage::assistant().content(summary).build());
+        self.messages.push_back(
+            crate::chat::ChatMessage::assistant()
+                .content(summary)
+                .build(),
+        );
         self.needs_summary = false;
     }
 }
@@ -200,7 +204,11 @@ impl MemoryProvider for SlidingWindowMemory {
 
     fn replace_with_summary(&mut self, summary: String) {
         self.messages.clear();
-        self.messages.push_back(crate::chat::ChatMessage::assistant().content(summary).build());
+        self.messages.push_back(
+            crate::chat::ChatMessage::assistant()
+                .content(summary)
+                .build(),
+        );
         self.needs_summary = false;
     }
 }


### PR DESCRIPTION
### PR — Reactive memory + conditional triggers

This patch lets agents wake up automatically when another agent says something that meets a condition—no loops, no timers.

#### What’s new

* `SharedMemory::new_reactive`
  Creates the same shared memory as before, but now every `remember()` broadcasts an event that anyone can subscribe to (`memory.subscribe()`).

* `on_message_from_with_trigger(role, condition)`
  Same idea as `on_message_from`, but the agent fires only if the incoming message passes a `MessageCondition`:

```rust
MessageCondition::Any
MessageCondition::Eq("text")
MessageCondition::Contains("text")
MessageCondition::NotContains("text")
MessageCondition::LenGt(100)
MessageCondition::Custom(|msg| { /* your logic */ })
```

Nothing else changes; if you stick with `SharedMemory::new()` and `on_message_from()`, behaviour is identical to before.

#### Quick demo

```rust
// one reactive bus
let mem = SharedMemory::new_reactive(SlidingWindowMemory::new(10));

// -- proposer: talks first, fixes answer only if reviewer says REJECT
let proposer = LLMBuilder::new()
    .backend(LLMBackend::OpenAI)
    .role("assistant")
    .on_message_from_with_trigger("reviewer", MessageCondition::Contains("REJECT"))
    .system("Answer concisely; fix your answer if reviewer says REJECT.")
    .memory(mem.clone())
    .build()?;

// -- reviewer: always reviews the assistant
LLMBuilder::new()
    .model("claude-sonnet-4-20250514")
    .role("reviewer")
    .system("Reply ONLY ACCEPT or REJECT.")
    .on_message_from("assistant")
    .memory(mem.clone())
    .build()?;

// -- resumer: fires once the reviewer finally says ACCEPT
LLMBuilder::new()
    .backend(LLMBackend::OpenAI)
    .role("resumer")
    .on_message_from_with_trigger("reviewer", MessageCondition::Eq("ACCEPT"))
    .system("Summarize the conversation in one sentence.")
    .memory(mem.clone())
    .build()?;

// start the chain
proposer.chat(&[ChatMessage::user()
    .content("how many R in the word strawberry ?")
    .build()]).await?;

// print the live stream
let mut rx = mem.subscribe();
while let Ok(evt) = rx.recv().await {
    println!("{}: {}", evt.role, evt.msg.content);
}
```

Run it and watch the agents coordinate on their own. No orchestrator, no busy-waiting.
