### PR TITLE
Enable complex JSON schemas for function calling tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ More details in the [`api_example`](examples/api_example.rs)
 | [`google_image`](examples/google_image.rs) | Google Gemini chat with PDF attachment |
 | [`google_embedding_example`](examples/google_embedding_example.rs) | Basic Google Gemini embedding example with Gemini models |
 | [`tool_calling_example`](examples/tool_calling_example.rs) | Basic tool calling example with OpenAI |
+| [`google_tool_calling_example`](examples/google_tool_calling_example.rs) | Google Gemini function calling example with complex JSON schema for meeting scheduling |
+| [`json_schema_nested_example`](examples/json_schema_nested_example.rs) | Advanced example demonstrating deeply nested JSON schemas with arrays of objects and complex data structures |
+| [`tool_json_schema_cycle_example`](examples/tool_json_schema_cycle_example.rs) | Complete tool calling cycle with JSON schema validation and structured responses |
 | [`unified_tool_calling_example`](examples/unified_tool_calling_example.rs) | Unified tool calling with selectable provider - demonstrates multi-turn tool use and tool choice |
 | [`deepclaude_pipeline_example`](examples/deepclaude_pipeline_example.rs) | Basic deepclaude pipeline example with DeepSeek and Claude |
 | [`api_example`](examples/api_example.rs) | Basic API (openai standard format) example with OpenAI, Anthropic, DeepSeek and Groq |

--- a/examples/google_tool_calling_example.rs
+++ b/examples/google_tool_calling_example.rs
@@ -1,0 +1,135 @@
+//! Example demonstrating tool/function calling with Google's Gemini model
+//! 
+//! This example shows how to:
+//! - Configure a Google LLM with function calling capabilities
+//! - Define a meeting scheduling function with JSON schema
+//! - Process function calls and handle responses
+//! - Maintain a conversation with tool usage
+
+use llm::{
+    builder::{FunctionBuilder, LLMBackend, LLMBuilder},
+    chat::ChatMessage,
+    FunctionCall, ToolCall,
+};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = std::env::var("GOOGLE_API_KEY").unwrap_or("test-key".to_string());
+
+    let llm = LLMBuilder::new()
+        .backend(LLMBackend::Google)
+        .api_key(api_key)
+        .model("gemini-2.0-flash")
+        .max_tokens(1024)
+        .temperature(0.7)
+        .function(
+            FunctionBuilder::new("schedule_meeting")
+                .description("Schedules a meeting with specified attendees at a given time and date.")
+                .json_schema(json!({
+                    "type": "object",
+                    "properties": {
+                        "attendees": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "List of people attending the meeting."
+                        },
+                        "date": {
+                            "type": "string",
+                            "description": "Date of the meeting (e.g., '2024-07-29')"
+                        },
+                        "time": {
+                            "type": "string",
+                            "description": "Time of the meeting (e.g., '15:00')"
+                        },
+                        "topic": {
+                            "type": "string",
+                            "description": "The subject or topic of the meeting."
+                        }
+                    },
+                    "required": ["attendees", "date", "time", "topic"]
+                }))
+        )
+        .build()?;
+
+    let messages = vec![ChatMessage::user()
+        .content("Schedule a meeting with Bob and Alice for 03/27/2025 at 10:00 AM about the Q3 planning.")
+        .build()];
+
+    let response = llm.chat_with_tools(&messages, llm.tools()).await?;
+
+    if let Some(tool_calls) = response.tool_calls() {
+        println!("Tool calls requested:");
+        for call in &tool_calls {
+            println!("Function: {}", call.function.name);
+            println!("Arguments: {}", call.function.arguments);
+
+            let result = process_tool_call(call)?;
+            println!("Result: {}", serde_json::to_string_pretty(&result)?);
+        }
+
+        let mut conversation = messages;
+        conversation.push(
+            ChatMessage::assistant()
+                .tool_use(tool_calls.clone())
+                .build(),
+        );
+
+        let tool_results: Vec<ToolCall> = tool_calls
+            .iter()
+            .map(|call| {
+                let result = process_tool_call(call).unwrap();
+                ToolCall {
+                    id: call.id.clone(),
+                    call_type: "function".to_string(),
+                    function: FunctionCall {
+                        name: call.function.name.clone(),
+                        arguments: serde_json::to_string(&result).unwrap(),
+                    },
+                }
+            })
+            .collect();
+
+        conversation.push(ChatMessage::user().tool_result(tool_results).build());
+
+        let final_response = llm.chat_with_tools(&conversation, llm.tools()).await?;
+        println!("\nFinal response: {}", final_response);
+    } else {
+        println!("Direct response: {}", response);
+    }
+
+    Ok(())
+}
+
+/// Processes a tool call by executing the requested function with provided arguments
+/// 
+/// # Arguments
+/// * `tool_call` - The tool call containing function name and arguments to process
+/// 
+/// # Returns
+/// * A JSON value containing the result of the function execution
+/// 
+/// # Errors
+/// * If the function arguments cannot be parsed as JSON
+/// * If an unknown function is called
+fn process_tool_call(tool_call: &ToolCall) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+    match tool_call.function.name.as_str() {
+        "schedule_meeting" => {
+            let args: serde_json::Value = serde_json::from_str(&tool_call.function.arguments)?;
+            
+            Ok(json!({
+                "meeting_id": "mtg_12345",
+                "status": "scheduled",
+                "attendees": args["attendees"],
+                "date": args["date"],
+                "time": args["time"],
+                "topic": args["topic"],
+                "calendar_link": "https://calendar.google.com/event/mtg_12345"
+            }))
+        }
+        _ => Ok(json!({
+            "error": "Unknown function",
+            "function": tool_call.function.name
+        })),
+    }
+}

--- a/examples/json_schema_nested_example.rs
+++ b/examples/json_schema_nested_example.rs
@@ -1,0 +1,184 @@
+/// Example demonstrating complex nested JSON schema handling with LLM function calls
+/// 
+/// This example shows how to:
+/// - Define a complex JSON schema for event creation with nested data structures
+/// - Process chat messages with function calls
+/// - Handle nested JSON responses
+/// - Manage a multi-turn conversation with tool results
+use llm::{
+    builder::{FunctionBuilder, LLMBackend, LLMBuilder},
+    chat::ChatMessage,
+    FunctionCall, ToolCall,
+};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = std::env::var("GOOGLE_API_KEY").unwrap_or("test-key".to_string());
+
+    let llm = LLMBuilder::new()
+        .backend(LLMBackend::Google)
+        .api_key(api_key)
+        .model("gemini-2.0-flash")
+        .function(
+            FunctionBuilder::new("create_event")
+                .description("Creates a complex event with deeply nested data structures")
+                .json_schema(json!({
+                    "type": "object",
+                    "properties": {
+                        "event": {
+                            "type": "object",
+                            "properties": {
+                                "title": {"type": "string"},
+                                "location": {
+                                    "type": "object",
+                                    "properties": {
+                                        "venue": {"type": "string"},
+                                        "address": {
+                                            "type": "object",
+                                            "properties": {
+                                                "street": {"type": "string"},
+                                                "city": {"type": "string"},
+                                                "coordinates": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "lat": {"type": "number"},
+                                                        "lng": {"type": "number"}
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "attendees": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {"type": "string"},
+                                            "email": {"type": "string"},
+                                            "role": {"type": "string"},
+                                            "preferences": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "dietary": {"type": "string"},
+                                                    "accessibility": {"type": "boolean"},
+                                                    "notifications": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "email": {"type": "boolean"},
+                                                            "sms": {"type": "boolean"},
+                                                            "schedule": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "time": {"type": "string"},
+                                                                        "type": {"type": "string"}
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "required": ["event"]
+                }))
+        )
+        .build()?;
+
+    let messages = vec![ChatMessage::user()
+        .content("Create a team meeting at Google HQ in Mountain View for Alice (alice@corp.com, manager, vegetarian, needs accessibility, wants email and SMS notifications 1 hour before) and Bob (bob@corp.com, developer, no dietary restrictions, only email notifications 30 minutes before)")
+        .build()];
+
+    let response = llm.chat_with_tools(&messages, llm.tools()).await?;
+
+    if let Some(tool_calls) = response.tool_calls() {
+        println!("Complex nested schema handled successfully!");
+        for call in &tool_calls {
+            println!("Function: {}", call.function.name);
+            let args: serde_json::Value = serde_json::from_str(&call.function.arguments)?;
+            println!("Nested arguments: {}", serde_json::to_string_pretty(&args)?);
+            
+            let result = process_tool_call(call)?;
+            println!("Result: {}", serde_json::to_string_pretty(&result)?);
+        }
+
+        let mut conversation = messages;
+        conversation.push(
+            ChatMessage::assistant()
+                .tool_use(tool_calls.clone())
+                .build(),
+        );
+
+        let tool_results: Vec<ToolCall> = tool_calls
+            .iter()
+            .map(|call| {
+                let result = process_tool_call(call).unwrap();
+                ToolCall {
+                    id: call.id.clone(),
+                    call_type: "function".to_string(),
+                    function: FunctionCall {
+                        name: call.function.name.clone(),
+                        arguments: serde_json::to_string(&result).unwrap(),
+                    },
+                }
+            })
+            .collect();
+
+        conversation.push(ChatMessage::user().tool_result(tool_results).build());
+
+        let final_response = llm.chat_with_tools(&conversation, llm.tools()).await?;
+        println!("\nFinal response: {}", final_response);
+    } else {
+        println!("Direct response: {}", response);
+    }
+
+    Ok(())
+}
+
+/// Processes a tool call and returns a simulated response
+/// 
+/// # Arguments
+/// * `tool_call` - The tool call to process containing function name and arguments
+/// 
+/// # Returns
+/// * JSON response containing event details or error message
+fn process_tool_call(tool_call: &ToolCall) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+    match tool_call.function.name.as_str() {
+        "create_event" => {
+            let args: serde_json::Value = serde_json::from_str(&tool_call.function.arguments)?;
+            
+            Ok(json!({
+                "event_id": "evt_12345",
+                "status": "created",
+                "created_at": "2025-01-06T10:30:00Z",
+                "calendar_links": {
+                    "google": "https://calendar.google.com/event/evt_12345",
+                    "outlook": "https://outlook.com/event/evt_12345"
+                },
+                "notifications_scheduled": args["event"]["attendees"]
+                    .as_array()
+                    .unwrap_or(&vec![])
+                    .iter()
+                    .map(|attendee| {
+                        json!({
+                            "attendee": attendee["email"],
+                            "notifications": attendee["preferences"]["notifications"]
+                        })
+                    })
+                    .collect::<Vec<_>>()
+            }))
+        }
+        _ => Ok(json!({
+            "error": "Unknown function",
+            "function": tool_call.function.name
+        })),
+    }
+}

--- a/examples/tool_json_schema_cycle_example.rs
+++ b/examples/tool_json_schema_cycle_example.rs
@@ -1,0 +1,109 @@
+//! End-to-end example showing a realistic tool-use cycle:
+//! 1. The user asks to import users.
+//! 2. The model replies with a `tool_use` call.
+//! 3. We execute the function on our side (mock).
+//! 4. We send back a `tool_result` message.
+//! 5. The model produces a final confirmation message.
+
+use llm::builder::{FunctionBuilder, LLMBackend, LLMBuilder};
+use llm::chat::{ChatMessage, ToolChoice};
+use llm::{FunctionCall, ToolCall};
+use serde::Deserialize;
+use serde_json::json;
+
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct User {
+    name: String,
+    emails: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ImportUsersArgs {
+    users: Vec<User>,
+}
+
+
+fn import_users_tool() -> FunctionBuilder {
+    let schema = json!({
+        "type": "object",
+        "properties": {
+            "users": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" },
+                        "emails": {
+                            "type": "array",
+                            "items": { "type": "string", "format": "email" }
+                        }
+                    },
+                    "required": ["name", "emails"],
+                    "additionalProperties": false
+                }
+            }
+        },
+        "required": ["users"],
+        "additionalProperties": false
+    });
+
+    FunctionBuilder::new("import_users")
+        .description("Bulk-import a list of users with their email addresses.")
+        .json_schema(schema)
+}
+
+fn import_users(args_json: &str) -> Result<usize, Box<dyn std::error::Error>> {
+    let args: ImportUsersArgs = serde_json::from_str(args_json)?;
+    println!("[server] imported {} users", args.users.len());
+    Ok(args.users.len())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let llm = LLMBuilder::new()
+        .backend(LLMBackend::OpenAI)
+        .api_key(std::env::var("OPENAI_API_KEY")?)
+        .model("gpt-4o")
+        .function(import_users_tool())
+        .tool_choice(ToolChoice::Any)
+        .build()?;
+
+    let mut messages = vec![ChatMessage::user()
+        .content("Please import Alice <alice@example.com> and Bob <bob@example.com>.")
+        .build()];
+
+    let first_resp = llm.chat(&messages).await?;
+    println!("[assistant] {}", first_resp);
+
+    if let Some(tool_calls) = first_resp.tool_calls() {
+        let mut tool_results = Vec::new();
+        for call in &tool_calls {
+            match import_users(&call.function.arguments) {
+                Ok(count) => {
+                    // Prepare a ToolResult conveying success.
+                    tool_results.push(ToolCall {
+                        id: call.id.clone(),
+                        call_type: "function".into(),
+                        function: FunctionCall {
+                            name: call.function.name.clone(),
+                            arguments: json!({ "status": "ok", "imported": count }).to_string(),
+                        },
+                    });
+                }
+                Err(e) => {
+                    eprintln!("[server] import failed: {e}");
+                }
+            }
+        }
+
+        messages.push(ChatMessage::assistant().tool_use(tool_calls).build());
+        messages.push(ChatMessage::assistant().tool_result(tool_results).build());
+
+        let final_resp = llm.chat(&messages).await?;
+        println!("[assistant] {}", final_resp);
+    }
+
+    Ok(())
+}

--- a/src/backends/azure_openai.rs
+++ b/src/backends/azure_openai.rs
@@ -448,6 +448,13 @@ impl ChatProvider for AzureOpenAI {
         let response_format: Option<OpenAIResponseFormat> =
             self.json_schema.clone().map(|s| s.into());
 
+        let request_tools = tools.map(|t| t.to_vec()).or_else(|| self.tools.clone());
+        let request_tool_choice = if request_tools.is_some() {
+            self.tool_choice.clone()
+        } else {
+            None
+        };
+
         let body = AzureOpenAIChatRequest {
             model: &self.model,
             messages: openai_msgs,
@@ -456,8 +463,8 @@ impl ChatProvider for AzureOpenAI {
             stream: self.stream.unwrap_or(false),
             top_p: self.top_p,
             top_k: self.top_k,
-            tools: tools.map(|t| t.to_vec()),
-            tool_choice: self.tool_choice.clone(),
+            tools: request_tools,
+            tool_choice: request_tool_choice,
             reasoning_effort: self.reasoning_effort.clone(),
             response_format,
         };

--- a/src/backends/openai.rs
+++ b/src/backends/openai.rs
@@ -406,9 +406,16 @@ impl ChatProvider for OpenAI {
             );
         }
 
-        // Build the response format object
         let response_format: Option<OpenAIResponseFormat> =
             self.json_schema.clone().map(|s| s.into());
+
+        let request_tools = tools.map(|t| t.to_vec()).or_else(|| self.tools.clone());
+
+        let request_tool_choice = if request_tools.is_some() {
+            self.tool_choice.clone()
+        } else {
+            None
+        };
 
         let body = OpenAIChatRequest {
             model: &self.model,
@@ -418,8 +425,8 @@ impl ChatProvider for OpenAI {
             stream: self.stream.unwrap_or(false),
             top_p: self.top_p,
             top_k: self.top_k,
-            tools: tools.map(|t| t.to_vec()),
-            tool_choice: self.tool_choice.clone(),
+            tools: request_tools,
+            tool_choice: request_tool_choice,
             reasoning_effort: self.reasoning_effort.clone(),
             response_format,
         };

--- a/src/chat/mod.rs
+++ b/src/chat/mod.rs
@@ -108,15 +108,23 @@ pub struct ParametersSchema {
     pub required: Vec<String>,
 }
 
-/// Represents a function definition for a tool
+/// Represents a function definition for a tool.
+///
+/// The `parameters` field stores the JSON Schema describing the function
+/// arguments.  It is kept as a raw `serde_json::Value` to allow arbitrary
+/// complexity (nested arrays/objects, `oneOf`, etc.) without requiring a
+/// bespoke Rust structure.
+///
+/// Builder helpers can still generate simple schemas automatically, but the
+/// user may also provide any valid schema directly.
 #[derive(Debug, Clone, Serialize)]
 pub struct FunctionTool {
-    /// The name of the function
+    /// Name of the function
     pub name: String,
-    /// Description of what the function does
+    /// Human-readable description
     pub description: String,
-    /// The parameters schema for the function
-    pub parameters: ParametersSchema,
+    /// JSON Schema describing the parameters
+    pub parameters: Value,
 }
 
 /// Defines rules for structured output responses based on [OpenAI's structured output requirements](https://platform.openai.com/docs/api-reference/chat/create#chat-create-response_format).


### PR DESCRIPTION
  This PR enhances the function calling system to support arbitrary JSON Schema complexity for tool parameters.

  ## Problem
  The previous implementation used a rigid `ParametersSchema` struct that limited function parameters to simple types and arrays. Complex nested objects, oneOf schemas, and other advanced JSON Schema
  features were not supported through the builder API.

  ## Solution
  - Changed `FunctionTool.parameters` from `ParametersSchema` to `serde_json::Value` for flexibility
  - Added `json_schema()` method to `FunctionBuilder` to accept raw JSON Schema
  - Updated all backends (OpenAI, Anthropic, Google, Ollama, Azure OpenAI) to handle the new schema format
  - Preserved backwards compatibility with existing parameter builder DSL

  ## Technical Changes
  - **Core**: Modified `FunctionTool` to store parameters as `serde_json::Value`
  - **Builder**: Added `raw_schema` field and `json_schema()` method for complex schemas
  - **Backends**: Updated schema conversion logic across all providers
  - **Google**: Fixed tool response formatting and parameter extraction

  ## Usage
  Simple schemas continue to work with the existing DSL:
  ```rust
  .param(ParamBuilder::new("name").type_of("string"))
  ```
  Complex schemas now supported via JSON Schema:
  ```rust
  .json_schema(json!({
      "type": "object",
      "properties": {
          "user": {
              "type": "object",
              "properties": {
                  "preferences": { /* nested objects */ }
              }
          }
      }
  }))
  ```
  This maintains the simplicity for basic use cases while enabling full JSON Schema power for advanced scenarios.