### PR TITLE
Add streaming support for OpenAI, Anthropic, Google, and X.AI providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,18 +63,22 @@ More details in the [`api_example`](examples/api_example.rs)
 | Name | Description |
 |------|-------------|
 | [`anthropic_example`](examples/anthropic_example.rs) | Demonstrates integration with Anthropic's Claude model for chat completion |
+| [`anthropic_streaming_example`](examples/anthropic_streaming_example.rs) | Anthropic streaming chat example demonstrating real-time token generation |
 | [`chain_example`](examples/chain_example.rs) | Shows how to create multi-step prompt chains for exploring programming language features |
 | [`deepseek_example`](examples/deepseek_example.rs) | Basic DeepSeek chat completion example with deepseek-chat models |
 | [`embedding_example`](examples/embedding_example.rs) | Basic embedding example with OpenAI's API |
 | [`multi_backend_example`](examples/multi_backend_example.rs) | Illustrates chaining multiple LLM backends (OpenAI, Anthropic, DeepSeek) together in a single workflow |
 | [`ollama_example`](examples/ollama_example.rs) | Example of using local LLMs through Ollama integration |
 | [`openai_example`](examples/openai_example.rs) | Basic OpenAI chat completion example with GPT models |
+| [`openai_streaming_example`](examples/openai_streaming_example.rs) | OpenAI streaming chat example demonstrating real-time token generation |
 | [`phind_example`](examples/phind_example.rs) | Basic Phind chat completion example with Phind-70B model |
 | [`validator_example`](examples/validator_example.rs) | Basic validator example with Anthropic's Claude model |
 | [`xai_example`](examples/xai_example.rs) | Basic xAI chat completion example with Grok models |
+| [`xai_streaming_example`](examples/xai_streaming_example.rs) | X.AI streaming chat example demonstrating real-time token generation |
 | [`evaluation_example`](examples/evaluation_example.rs) | Basic evaluation example with Anthropic, Phind and DeepSeek |
 | [`evaluator_parallel_example`](examples/evaluator_parallel_example.rs) | Evaluate multiple LLM providers in parallel |
 | [`google_example`](examples/google_example.rs) | Basic Google Gemini chat completion example with Gemini models |
+| [`google_streaming_example`](examples/google_streaming_example.rs) | Google streaming chat example demonstrating real-time token generation |
 | [`google_pdf`](examples/google_pdf.rs) | Google Gemini chat with PDF attachment |
 | [`google_image`](examples/google_image.rs) | Google Gemini chat with PDF attachment |
 | [`google_embedding_example`](examples/google_embedding_example.rs) | Basic Google Gemini embedding example with Gemini models |

--- a/examples/anthropic_streaming_example.rs
+++ b/examples/anthropic_streaming_example.rs
@@ -1,0 +1,49 @@
+// Anthropic streaming chat example demonstrating real-time token generation
+use futures::StreamExt;
+use llm::{
+    builder::{LLMBackend, LLMBuilder},
+    chat::ChatMessage,
+};
+use std::io::{self, Write};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Get Anthropic API key from environment variable or use test key as fallback
+    let api_key = std::env::var("ANTHROPIC_API_KEY").unwrap_or("sk-TESTKEY".into());
+
+    // Initialize and configure the LLM client with streaming enabled
+    let llm = LLMBuilder::new()
+        .backend(LLMBackend::Anthropic)
+        .api_key(api_key)
+        .model("claude-3-haiku-20240307")
+        .max_tokens(1000)
+        .temperature(0.7)
+        .stream(true) // Enable streaming responses
+        .build()
+        .expect("Failed to build LLM (Anthropic)");
+
+    // Prepare conversation with a prompt that will generate a longer response
+    let messages = vec![
+        ChatMessage::user()
+            .content("Write a long story about a robot learning to paint. Make it creative and engaging.")
+            .build(),
+    ];
+
+    println!("Starting streaming chat with Anthropic...\n");
+
+    match llm.chat_stream(&messages).await {
+        Ok(mut stream) => {
+            let stdout = io::stdout();
+            let mut handle = stdout.lock();
+            
+            while let Some(Ok(token)) = stream.next().await {
+                handle.write_all(token.as_bytes()).unwrap();
+                handle.flush().unwrap();
+            }
+            println!("\n\nStreaming completed.");
+        }
+        Err(e) => eprintln!("Chat error: {}", e),
+    }
+
+    Ok(())
+}

--- a/examples/google_streaming_example.rs
+++ b/examples/google_streaming_example.rs
@@ -1,0 +1,49 @@
+// Google streaming chat example demonstrating real-time token generation
+use futures::StreamExt;
+use llm::{
+    builder::{LLMBackend, LLMBuilder},
+    chat::ChatMessage,
+};
+use std::io::{self, Write};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Get Google API key from environment variable or use test key as fallback
+    let api_key = std::env::var("GOOGLE_API_KEY=").unwrap_or("TESTKEY".into());
+
+    // Initialize and configure the LLM client with streaming enabled
+    let llm = LLMBuilder::new()
+        .backend(LLMBackend::Google)
+        .api_key(api_key)
+        .model("gemini-2.0-flash")
+        .max_tokens(1000)
+        .temperature(0.7)
+        .stream(true) // Enable streaming responses
+        .build()
+        .expect("Failed to build LLM (Google)");
+
+    // Prepare conversation with a prompt that will generate a longer response
+    let messages = vec![
+        ChatMessage::user()
+            .content("Write a long story about a robot learning to paint. Make it creative and engaging.")
+            .build(),
+    ];
+
+    println!("Starting streaming chat with Google...\n");
+
+    match llm.chat_stream(&messages).await {
+        Ok(mut stream) => {
+            let stdout = io::stdout();
+            let mut handle = stdout.lock();
+            
+            while let Some(Ok(token)) = stream.next().await {
+                handle.write_all(token.as_bytes()).unwrap();
+                handle.flush().unwrap();
+            }
+            println!("\n\nStreaming completed.");
+        }
+        Err(e) => eprintln!("Chat error: {}", e),
+    }
+
+    Ok(())
+}

--- a/examples/openai_streaming_example.rs
+++ b/examples/openai_streaming_example.rs
@@ -1,0 +1,49 @@
+// OpenAI streaming chat example demonstrating real-time token generation
+use futures::StreamExt;
+use llm::{
+    builder::{LLMBackend, LLMBuilder},
+    chat::ChatMessage,
+};
+use std::io::{self, Write};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Get OpenAI API key from environment variable or use test key as fallback
+    let api_key = std::env::var("OPENAI_API_KEY").unwrap_or("sk-TESTKEY".into());
+
+    // Initialize and configure the LLM client with streaming enabled
+    let llm = LLMBuilder::new()
+        .backend(LLMBackend::OpenAI)
+        .api_key(api_key)
+        .model("gpt-3.5-turbo")
+        // .max_tokens(512)
+        .temperature(0.7)
+        .stream(true) // Enable streaming responses
+        .build()
+        .expect("Failed to build LLM (OpenAI)");
+
+    // Prepare conversation with a prompt that will generate a longer response
+    let messages = vec![
+        ChatMessage::user()
+            .content("Write a long story about a robot learning to paint. Make it creative and engaging.")
+            .build(),
+    ];
+
+    println!("Starting streaming chat with OpenAI...\n");
+
+    match llm.chat_stream(&messages).await {
+        Ok(mut stream) => {
+            let stdout = io::stdout();
+            let mut handle = stdout.lock();
+            
+            while let Some(Ok(token)) = stream.next().await {
+                handle.write_all(token.as_bytes()).unwrap();
+                handle.flush().unwrap();
+            }
+            println!("\n\nStreaming completed.");
+        }
+        Err(e) => eprintln!("Chat error: {}", e),
+    }
+
+    Ok(())
+}

--- a/examples/xai_streaming_example.rs
+++ b/examples/xai_streaming_example.rs
@@ -1,0 +1,49 @@
+// X.AI streaming chat example demonstrating real-time token generation
+use futures::StreamExt;
+use llm::{
+    builder::{LLMBackend, LLMBuilder},
+    chat::ChatMessage,
+};
+use std::io::{self, Write};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Get X.AI API key from environment variable or use test key as fallback
+    let api_key = std::env::var("XAI_API_KEY").unwrap_or("xai-TESTKEY".into());
+
+    // Initialize and configure the LLM client with streaming enabled
+    let llm = LLMBuilder::new()
+        .backend(LLMBackend::XAI)
+        .api_key(api_key)
+        .model("grok-2-latest")
+        .max_tokens(1000)
+        .temperature(0.7)
+        .stream(true) // Enable streaming responses
+        .build()
+        .expect("Failed to build LLM (X.AI)");
+
+    // Prepare conversation with a prompt that will generate a longer response
+    let messages = vec![
+        ChatMessage::user()
+            .content("Write a long story about a robot learning to paint. Make it creative and engaging.")
+            .build(),
+    ];
+
+    println!("Starting streaming chat with X.AI...\n");
+
+    match llm.chat_stream(&messages).await {
+        Ok(mut stream) => {
+            let stdout = io::stdout();
+            let mut handle = stdout.lock();
+            
+            while let Some(Ok(token)) = stream.next().await {
+                handle.write_all(token.as_bytes()).unwrap();
+                handle.flush().unwrap();
+            }
+            println!("\n\nStreaming completed.");
+        }
+        Err(e) => eprintln!("Chat error: {}", e),
+    }
+
+    Ok(())
+}

--- a/src/backends/xai.rs
+++ b/src/backends/xai.rs
@@ -19,6 +19,7 @@ use crate::{
     ToolCall,
 };
 use async_trait::async_trait;
+use futures::stream::Stream;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 
@@ -145,6 +146,28 @@ struct XAIEmbeddingRequest<'a> {
 struct XAIEmbeddingData {
     embedding: Vec<f32>,
 }
+
+/// Response from X.AI's streaming chat API endpoint.
+#[derive(Deserialize, Debug)]
+struct XAIStreamResponse {
+    /// Array of generated responses
+    choices: Vec<XAIStreamChoice>,
+}
+
+/// Individual response choice from the streaming chat API.
+#[derive(Deserialize, Debug)]
+struct XAIStreamChoice {
+    /// Delta content
+    delta: XAIStreamDelta,
+}
+
+/// Delta content from a streaming chat response.
+#[derive(Deserialize, Debug)]
+struct XAIStreamDelta {
+    /// Generated text content
+    content: Option<String>,
+}
+
 #[derive(Deserialize)]
 struct XAIEmbeddingResponse {
     data: Vec<XAIEmbeddingData>,
@@ -333,6 +356,80 @@ impl ChatProvider for XAI {
         // XAI doesn't support tools yet, fall back to regular chat
         self.chat(messages).await
     }
+
+    /// Sends a streaming chat request to X.AI's API.
+    ///
+    /// # Arguments
+    ///
+    /// * `messages` - Slice of chat messages representing the conversation
+    ///
+    /// # Returns
+    ///
+    /// A stream of text tokens or an error
+    async fn chat_stream(
+        &self,
+        messages: &[ChatMessage],
+    ) -> Result<std::pin::Pin<Box<dyn Stream<Item = Result<String, LLMError>> + Send>>, LLMError> {
+        if self.api_key.is_empty() {
+            return Err(LLMError::AuthError("Missing X.AI API key".to_string()));
+        }
+
+        let mut xai_msgs: Vec<XAIChatMessage> = messages
+            .iter()
+            .map(|m| XAIChatMessage {
+                role: match m.role {
+                    ChatRole::User => "user",
+                    ChatRole::Assistant => "assistant",
+                },
+                content: &m.content,
+            })
+            .collect();
+
+        if let Some(system) = &self.system {
+            xai_msgs.insert(
+                0,
+                XAIChatMessage {
+                    role: "system",
+                    content: system,
+                },
+            );
+        }
+
+        let body = XAIChatRequest {
+            model: &self.model,
+            messages: xai_msgs,
+            max_tokens: self.max_tokens,
+            temperature: self.temperature,
+            stream: true,
+            top_p: self.top_p,
+            top_k: self.top_k,
+            response_format: None,
+            search_parameters: None,
+        };
+
+        let mut request = self
+            .client
+            .post("https://api.x.ai/v1/chat/completions")
+            .bearer_auth(&self.api_key)
+            .json(&body);
+
+        if let Some(timeout) = self.timeout_seconds {
+            request = request.timeout(std::time::Duration::from_secs(timeout));
+        }
+
+        let response = request.send().await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await?;
+            return Err(LLMError::ResponseFormatError {
+                message: format!("X.AI API returned error status: {}", status),
+                raw_response: error_text,
+            });
+        }
+
+        Ok(crate::chat::create_sse_stream(response, parse_xai_sse_chunk))
+    }
 }
 
 #[async_trait]
@@ -403,3 +500,42 @@ impl SpeechToTextProvider for XAI {
 impl TextToSpeechProvider for XAI {}
 
 impl LLMProvider for XAI {}
+
+/// Parses a Server-Sent Events (SSE) chunk from X.AI's streaming API.
+///
+/// # Arguments
+///
+/// * `chunk` - The raw SSE chunk text
+///
+/// # Returns
+///
+/// * `Ok(Some(String))` - Content token if found
+/// * `Ok(None)` - If chunk should be skipped (e.g., ping, done signal)
+/// * `Err(LLMError)` - If parsing fails
+fn parse_xai_sse_chunk(chunk: &str) -> Result<Option<String>, LLMError> {
+    for line in chunk.lines() {
+        let line = line.trim();
+        
+        if line.starts_with("data: ") {
+            let data = &line[6..];
+            
+            if data == "[DONE]" {
+                return Ok(None);
+            }
+            
+            match serde_json::from_str::<XAIStreamResponse>(data) {
+                Ok(response) => {
+                    if let Some(choice) = response.choices.first() {
+                        if let Some(content) = &choice.delta.content {
+                            return Ok(Some(content.clone()));
+                        }
+                    }
+                    return Ok(None);
+                }
+                Err(_) => continue,
+            }
+        }
+    }
+    
+    Ok(None)
+}

--- a/src/chat/mod.rs
+++ b/src/chat/mod.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::fmt;
 
 use async_trait::async_trait;
+use futures::stream::{Stream, StreamExt};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -276,6 +277,24 @@ pub trait ChatProvider: Sync + Send {
         tools: Option<&[Tool]>,
     ) -> Result<Box<dyn ChatResponse>, LLMError>;
 
+    /// Sends a streaming chat request to the provider with a sequence of messages.
+    ///
+    /// # Arguments
+    ///
+    /// * `messages` - The conversation history as a slice of chat messages
+    ///
+    /// # Returns
+    ///
+    /// A stream of text tokens or an error
+    async fn chat_stream(
+        &self,
+        _messages: &[ChatMessage],
+    ) -> Result<std::pin::Pin<Box<dyn Stream<Item = Result<String, LLMError>> + Send>>, LLMError> {
+        Err(LLMError::Generic(
+            "Streaming not supported for this provider".to_string(),
+        ))
+    }
+
     /// Get current memory contents if provider supports memory
     async fn memory_contents(&self) -> Option<Vec<ChatMessage>> {
         None
@@ -391,4 +410,41 @@ impl ChatMessageBuilder {
             content: self.content,
         }
     }
+}
+
+/// Creates a Server-Sent Events (SSE) stream from an HTTP response.
+///
+/// # Arguments
+///
+/// * `response` - The HTTP response from the streaming API
+/// * `parser` - Function to parse each SSE chunk into optional text content
+///
+/// # Returns
+///
+/// A pinned stream of text tokens or an error
+pub(crate) fn create_sse_stream<F>(
+    response: reqwest::Response,
+    parser: F,
+) -> std::pin::Pin<Box<dyn Stream<Item = Result<String, LLMError>> + Send>>
+where
+    F: Fn(&str) -> Result<Option<String>, LLMError> + Send + 'static,
+{
+    let stream = response
+        .bytes_stream()
+        .map(move |chunk| match chunk {
+            Ok(bytes) => {
+                let text = String::from_utf8_lossy(&bytes);
+                parser(&text)
+            }
+            Err(e) => Err(LLMError::HttpError(e.to_string())),
+        })
+        .filter_map(|result| async move {
+            match result {
+                Ok(Some(content)) => Some(Ok(content)),
+                Ok(None) => None,
+                Err(e) => Some(Err(e)),
+            }
+        });
+
+    Box::pin(stream)
 }


### PR DESCRIPTION
Implements real-time streaming chat functionality across major LLM providers. Adds chat_stream() method to the ChatProvider trait with provider-specific SSE parsing and unified stream handling. Includes
   streaming examples for each supported provider and maintains backward compatibility with existing non-streaming APIs.

  Changes:
  - Add chat_stream() method to ChatProvider trait
  - Implement streaming for OpenAI, Anthropic, Google Gemini, and X.AI
  - Add create_sse_stream() helper function to reduce code duplication
  - Include streaming examples for all supported providers
  - Update README with new streaming examples