### PR TITLE
Add model list provider with implementation for openai and anthropic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,6 +290,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,6 +1178,7 @@ dependencies = [
  "async-trait",
  "axum",
  "base64",
+ "chrono",
  "clap",
  "colored",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ rodio = { version = "0.20.0", features = ["mp3", "wav"], optional = true }
 regex = "1.10"
 log = "0.4"
 env_logger = { version = "0.11", optional = true }
+chrono = {version = "0.4", default-features = false, features = ["serde"]}
 
 [[bin]]
 name = "llm"

--- a/src/backends/azure_openai.rs
+++ b/src/backends/azure_openai.rs
@@ -9,6 +9,7 @@ use crate::{
     completion::{CompletionProvider, CompletionRequest, CompletionResponse},
     embedding::EmbeddingProvider,
     error::LLMError,
+    models::ModelsProvider,
     stt::SpeechToTextProvider,
     tts::TextToSpeechProvider,
     LLMProvider,
@@ -606,3 +607,6 @@ impl TextToSpeechProvider for AzureOpenAI {
         ))
     }
 }
+
+#[async_trait]
+impl ModelsProvider for AzureOpenAI {}

--- a/src/backends/deepseek.rs
+++ b/src/backends/deepseek.rs
@@ -9,6 +9,7 @@ use crate::{
     completion::{CompletionProvider, CompletionRequest, CompletionResponse},
     embedding::EmbeddingProvider,
     error::LLMError,
+    models::ModelsProvider,
     stt::SpeechToTextProvider,
     tts::TextToSpeechProvider,
     LLMProvider,
@@ -224,6 +225,9 @@ impl SpeechToTextProvider for DeepSeek {
         ))
     }
 }
+
+#[async_trait]
+impl ModelsProvider for DeepSeek {}
 
 impl LLMProvider for DeepSeek {}
 

--- a/src/backends/elevenlabs.rs
+++ b/src/backends/elevenlabs.rs
@@ -3,6 +3,7 @@ use crate::completion::{CompletionProvider, CompletionRequest, CompletionRespons
 use crate::embedding::EmbeddingProvider;
 #[cfg(feature = "elevenlabs")]
 use crate::error::LLMError;
+use crate::models::ModelsProvider;
 use crate::stt::SpeechToTextProvider;
 use crate::tts::TextToSpeechProvider;
 use crate::LLMProvider;
@@ -250,6 +251,9 @@ impl ChatProvider for ElevenLabs {
         ))
     }
 }
+
+#[async_trait]
+impl ModelsProvider for ElevenLabs {}
 
 impl LLMProvider for ElevenLabs {
     /// Returns None as no tools are supported

--- a/src/backends/google.rs
+++ b/src/backends/google.rs
@@ -49,6 +49,7 @@ use crate::{
     completion::{CompletionProvider, CompletionRequest, CompletionResponse},
     embedding::EmbeddingProvider,
     error::LLMError,
+    models::ModelsProvider,
     stt::SpeechToTextProvider,
     tts::TextToSpeechProvider,
     FunctionCall, LLMProvider, ToolCall,
@@ -1050,3 +1051,6 @@ fn parse_google_sse_chunk(chunk: &str) -> Result<Option<String>, LLMError> {
 
 #[async_trait]
 impl TextToSpeechProvider for Google {}
+
+#[async_trait]
+impl ModelsProvider for Google {}

--- a/src/backends/groq.rs
+++ b/src/backends/groq.rs
@@ -7,6 +7,7 @@ use crate::{
     completion::{CompletionProvider, CompletionRequest, CompletionResponse},
     embedding::EmbeddingProvider,
     error::LLMError,
+    models::ModelsProvider,
     stt::SpeechToTextProvider,
     tts::TextToSpeechProvider,
     LLMProvider, ToolCall,
@@ -223,5 +224,8 @@ impl SpeechToTextProvider for Groq {
 
 #[async_trait]
 impl TextToSpeechProvider for Groq {}
+
+#[async_trait]
+impl ModelsProvider for Groq {}
 
 impl LLMProvider for Groq {}

--- a/src/backends/ollama.rs
+++ b/src/backends/ollama.rs
@@ -7,6 +7,7 @@ use crate::{
     completion::{CompletionProvider, CompletionRequest, CompletionResponse},
     embedding::EmbeddingProvider,
     error::LLMError,
+    models::ModelsProvider,
     stt::SpeechToTextProvider,
     tts::TextToSpeechProvider,
     FunctionCall, ToolCall,
@@ -537,6 +538,9 @@ impl SpeechToTextProvider for Ollama {
         ))
     }
 }
+
+#[async_trait]
+impl ModelsProvider for Ollama {}
 
 impl crate::LLMProvider for Ollama {
     fn tools(&self) -> Option<&[Tool]> {

--- a/src/backends/phind.rs
+++ b/src/backends/phind.rs
@@ -6,6 +6,7 @@ use crate::{
     completion::{CompletionProvider, CompletionRequest, CompletionResponse},
     embedding::EmbeddingProvider,
     error::LLMError,
+    models::ModelsProvider,
     stt::SpeechToTextProvider,
     tts::TextToSpeechProvider,
     LLMProvider,
@@ -296,6 +297,9 @@ impl SpeechToTextProvider for Phind {
         ))
     }
 }
+
+#[async_trait]
+impl ModelsProvider for Phind {}
 
 /// Implementation of the LLMProvider trait for Phind.
 #[async_trait]

--- a/src/backends/xai.rs
+++ b/src/backends/xai.rs
@@ -9,6 +9,7 @@ use crate::{
     completion::{CompletionProvider, CompletionRequest, CompletionResponse},
     embedding::EmbeddingProvider,
     error::LLMError,
+    models::ModelsProvider,
     stt::SpeechToTextProvider,
     tts::TextToSpeechProvider,
     LLMProvider,
@@ -553,6 +554,9 @@ impl SpeechToTextProvider for XAI {
 
 #[async_trait]
 impl TextToSpeechProvider for XAI {}
+
+#[async_trait]
+impl ModelsProvider for XAI {}
 
 impl LLMProvider for XAI {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,9 @@ pub mod tts;
 /// Secret store for storing API keys and other sensitive information
 pub mod secret_store;
 
+/// Listing models support
+pub mod models;
+
 /// Memory providers for storing and retrieving conversation history
 #[macro_use]
 pub mod memory;
@@ -84,6 +87,7 @@ pub trait LLMProvider:
     + embedding::EmbeddingProvider
     + stt::SpeechToTextProvider
     + tts::TextToSpeechProvider
+    + models::ModelsProvider
 {
     fn tools(&self) -> Option<&[Tool]> {
         None

--- a/src/memory/chat_wrapper.rs
+++ b/src/memory/chat_wrapper.rs
@@ -10,6 +10,7 @@ use crate::{
     embedding::EmbeddingProvider,
     error::LLMError,
     memory::{MemoryProvider, MessageCondition},
+    models::ModelsProvider,
     stt::SpeechToTextProvider,
     tts::TextToSpeechProvider,
     LLMProvider,
@@ -234,6 +235,9 @@ impl TextToSpeechProvider for ChatWithMemory {
         self.provider.speech(text).await
     }
 }
+
+#[async_trait]
+impl ModelsProvider for ChatWithMemory {}
 
 impl LLMProvider for ChatWithMemory {
     fn tools(&self) -> Option<&[Tool]> {

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,10 +1,23 @@
-use crate::error::LLMError;
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use crate::{
+    builder::LLMBackend,
+    error::LLMError,
+};
+use std::fmt::Debug;
 
 pub trait ModelListResponse {
     fn get_models(&self) -> Vec<String>;
-    fn get_models_raw(&self) -> Vec<serde_json::Value>;
+    fn get_models_raw(&self) -> Vec<Box<dyn ModelListRawEntry>>;
+    fn get_backend(&self) -> LLMBackend;
 }
+
+pub trait ModelListRawEntry: Debug {
+    fn get_id(&self) -> String;
+    fn get_created_at(&self) -> DateTime<Utc>;
+    fn get_raw(&self) -> serde_json::Value;
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct ModelListRequest {
     pub filter: Option<String>,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,0 +1,33 @@
+use crate::error::LLMError;
+use async_trait::async_trait;
+
+pub trait ModelListResponse {
+    fn get_models(&self) -> Vec<String>;
+    fn get_models_raw(&self) -> Vec<serde_json::Value>;
+}
+#[derive(Debug, Clone, Default)]
+pub struct ModelListRequest {
+    pub filter: Option<String>,
+}
+
+/// Trait for providers that support listing and retrieving model information.
+#[async_trait]
+pub trait ModelsProvider {
+    /// Asynchronously retrieves the list of available models ID's from the provider.
+    ///
+    /// # Arguments
+    ///
+    /// * `_request` - Optional filter by model ID
+    ///
+    /// # Returns
+    ///
+    /// List of model ID's or error
+    async fn list_models(
+        &self,
+        _request: Option<&ModelListRequest>,
+    ) -> Result<Box<dyn ModelListResponse>, LLMError> {
+        Err(LLMError::ProviderError(
+            "List Models not supported".to_string(),
+        ))
+    }
+}

--- a/src/validated_llm.rs
+++ b/src/validated_llm.rs
@@ -29,6 +29,7 @@ use crate::chat::{ChatMessage, ChatProvider, ChatResponse, ChatRole, MessageType
 use crate::completion::{CompletionProvider, CompletionRequest, CompletionResponse};
 use crate::embedding::EmbeddingProvider;
 use crate::error::LLMError;
+use crate::models::ModelsProvider;
 use crate::stt::SpeechToTextProvider;
 use crate::tts::TextToSpeechProvider;
 use crate::{builder::ValidatorFn, LLMProvider};
@@ -224,3 +225,6 @@ impl TextToSpeechProvider for ValidatedLLM {
         ))
     }
 }
+
+#[async_trait]
+impl ModelsProvider for ValidatedLLM {}


### PR DESCRIPTION
# Add `ModelsProvider`

This change introduces a `ModelsProvider`, which allows fetching a list of available models from the provider. It enables library clients to select or change models without using third-party or homemade tools.

Make `ModelsProvider` a mandatory dependency for `LLMProvider`. Implement `ModelsProvider` for OpenAI and Anthropic.

`ModelListResponse.get_models()` returns only list of model id's
`ModelListResponse.get_models_raw()` returns detailed data for each model

## Questions
My main concern is the return type of `get_models_raw`: `Vec<serde_json::Value>`. Different providers return different sets of fields for models. In Ollama, the data even includes nested objects and arrays. 

- Is it acceptable to use `serde_json::Value`, or would it be better to define a more structured type (for example, `HashMap<String, StringOrNumOrHashMapOrArray>`)?
- Should I return the `LLMBackend` alongside each entry (or with the whole response) so that clients can decide how to parse the raw model data?

If the design is OK, I will implement `ModelsProvider` for all other providers.

