### PR TITLE
Fix tool calling feature for Mistral backend

### DIFF
--- a/src/backends/mistral.rs
+++ b/src/backends/mistral.rs
@@ -155,21 +155,7 @@ struct MistralChatChoice {
 struct MistralChatMsg {
     role: String,
     content: Option<String>,
-    tool_calls: Option<Vec<MistralToolCall>>,
-}
-
-/// Mistral-specific tool call structure for parsing API responses.
-#[derive(Deserialize, Debug)]
-struct MistralToolCall {
-    pub id: String,
-    pub function: MistralToolFunction,
-}
-
-/// Mistral-specific function call structure.
-#[derive(Deserialize, Debug)]
-struct MistralToolFunction {
-    pub name: String,
-    pub arguments: String,
+    tool_calls: Option<Vec<ToolCall>>,
 }
 
 /// SSE (Server-Sent Events) chunk parser for Mistral's streaming responses.
@@ -275,21 +261,9 @@ impl ChatResponse for MistralChatResponse {
     }
 
     fn tool_calls(&self) -> Option<Vec<ToolCall>> {
-        self.choices.first().and_then(|c| {
-            c.message.tool_calls.as_ref().map(|calls| {
-                calls
-                    .iter()
-                    .map(|call| ToolCall {
-                        id: call.id.clone(),
-                        call_type: "function".to_string(),
-                        function: crate::FunctionCall {
-                            name: call.function.name.clone(),
-                            arguments: call.function.arguments.clone(),
-                        },
-                    })
-                    .collect()
-            })
-        })
+        self.choices
+            .first()
+            .and_then(|c| c.message.tool_calls.clone())
     }
 }
 

--- a/src/backends/mistral.rs
+++ b/src/backends/mistral.rs
@@ -295,19 +295,17 @@ impl ChatResponse for MistralChatResponse {
 
 impl std::fmt::Display for MistralChatResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let content = self.text();
-        let tool_calls = self.tool_calls();
-        match (content, tool_calls) {
+        match (&self.text(), &self.tool_calls()) {
             (Some(content), Some(tool_calls)) => {
                 for tool_call in tool_calls {
-                    write!(f, "{}", tool_call)?;
+                    write!(f, "{tool_call}")?;
                 }
-                write!(f, "{}", content)
+                write!(f, "{content}")
             }
-            (Some(content), None) => write!(f, "{}", content),
+            (Some(content), None) => write!(f, "{content}"),
             (None, Some(tool_calls)) => {
                 for tool_call in tool_calls {
-                    write!(f, "{}", tool_call)?;
+                    write!(f, "{tool_call}")?;
                 }
                 Ok(())
             }
@@ -500,7 +498,7 @@ impl ChatProvider for Mistral {
             let status = response.status();
             let error_text = response.text().await?;
             return Err(LLMError::ResponseFormatError {
-                message: format!("Mistral API returned error status: {}", status),
+                message: format!("Mistral API returned error status: {status}"),
                 raw_response: error_text,
             });
         }
@@ -512,7 +510,7 @@ impl ChatProvider for Mistral {
         match json_resp {
             Ok(res) => Ok(Box::new(res)),
             Err(e) => Err(LLMError::ResponseFormatError {
-                message: format!("Failed to decode Mistral API response: {}", e),
+                message: format!("Failed to decode Mistral API response: {e}"),
                 raw_response: resp_text,
             }),
         }
@@ -599,7 +597,7 @@ impl ChatProvider for Mistral {
             let status = response.status();
             let error_text = response.text().await?;
             return Err(LLMError::ResponseFormatError {
-                message: format!("Mistral API returned error status: {}", status),
+                message: format!("Mistral API returned error status: {status}"),
                 raw_response: error_text,
             });
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,11 +100,16 @@ pub trait LLMProvider:
 pub struct ToolCall {
     /// The ID of the tool call.
     pub id: String,
-    /// The type of the tool call (usually "function").
-    #[serde(rename = "type")]
+    /// The type of the tool call (defaults to "function" if not provided).
+    #[serde(rename = "type", default = "default_call_type")]
     pub call_type: String,
     /// The function to call.
     pub function: FunctionCall,
+}
+
+/// Default value for call_type field in ToolCall
+fn default_call_type() -> String {
+    "function".to_string()
 }
 
 /// FunctionCall contains details about which function to call and with what arguments.


### PR DESCRIPTION
I made the `type` field optional and added a `function` type by default to mistral tool calls

Not sure if this is how you want to handle it (maybe we prefer making the `type` optional at the `ToolCall` level)

I tested it and it works

Let me know if you want me to make any change