### PR TITLE
Add github action workflow to run tests and build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Tests
+on:
+  workflow_dispatch:
+  workflow_call:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    name: ✅ Test and build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup update
+      # - run: cargo fmt -- --check
+      - run: cargo clippy --all --all-targets --all-features
+      - run: cargo test
+      - run: cargo build --release

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # LLM
 
+[![Tests](https://github.com/graniet/llm/actions/workflows/test.yml/badge.svg)](https://github.com/graniet/llm/actions/workflows/test.yml)
+
 > **Note**: This crate name previously belonged to another project. The current implementation represents a new and different library. The previous crate is now archived and will not receive any updates. **ref: https://github.com/rustformers/llm**
 
 **LLM** is a **Rust** library that lets you use **multiple LLM backends** in a single project: [OpenAI](https://openai.com), [Anthropic (Claude)](https://www.anthropic.com), [Ollama](https://github.com/ollama/ollama), [DeepSeek](https://www.deepseek.com), [xAI](https://x.ai), [Phind](https://www.phind.com), [Groq](https://www.groq.com), [Google](https://cloud.google.com/gemini), [Cohere](https://cohere.com), [Mistral](https://mistral.ai) and [ElevenLabs](https://elevenlabs.io).


### PR DESCRIPTION
Added a github action workflow to run tests and make sure it builds (ran on push to main and PRs, can be run manually or from other workflows)
Added a badge to easily see the workflow status in the readme