### PR TITLE
Improve response normalization when streaming tool calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .model("gpt-4.1-nano") 				// Use GPT-4.1 Nano model
         .max_tokens(512) 							// Limit response length
         .temperature(0.7) 						// Control response randomness (0.0-1.0)
+        .normalize_response(true)     // Increase response normalization (e.g. function call stream)
         .build()
         .expect("Failed to build LLM");
 

--- a/src/backends/cohere.rs
+++ b/src/backends/cohere.rs
@@ -53,6 +53,7 @@ impl Cohere {
         reasoning_effort: Option<String>,
         json_schema: Option<StructuredOutputFormat>,
         parallel_tool_calls: Option<bool>,
+        normalize_response: Option<bool>,
     ) -> Self {
         <OpenAICompatibleProvider<CohereConfig>>::new(
             api_key,
@@ -70,6 +71,7 @@ impl Cohere {
             json_schema,
             None, // voice - not supported by Cohere
             parallel_tool_calls,
+            normalize_response,
             embedding_encoding_format,
             embedding_dimensions,
         )

--- a/src/backends/groq.rs
+++ b/src/backends/groq.rs
@@ -63,6 +63,7 @@ impl Groq {
         reasoning_effort: Option<String>,
         json_schema: Option<StructuredOutputFormat>,
         parallel_tool_calls: Option<bool>,
+        normalize_response: Option<bool>,
     ) -> Self {
         OpenAICompatibleProvider::<GroqConfig>::new(
             api_key,
@@ -80,6 +81,7 @@ impl Groq {
             json_schema,
             None, // voice - not supported by Groq
             parallel_tool_calls,
+            normalize_response,
             None, // embedding_encoding_format - not supported by Groq
             None, // embedding_dimensions - not supported by Groq
         )

--- a/src/backends/mistral.rs
+++ b/src/backends/mistral.rs
@@ -51,6 +51,7 @@ impl Mistral {
         reasoning_effort: Option<String>,
         json_schema: Option<StructuredOutputFormat>,
         parallel_tool_calls: Option<bool>,
+        normalize_response: Option<bool>,
     ) -> Self {
         <OpenAICompatibleProvider<MistralConfig>>::new(
             api_key,
@@ -68,6 +69,7 @@ impl Mistral {
             json_schema,
             None, // voice - not supported by Mistral
             parallel_tool_calls,
+            normalize_response,
             embedding_encoding_format,
             embedding_dimensions,
         )

--- a/src/backends/openai.rs
+++ b/src/backends/openai.rs
@@ -204,6 +204,7 @@ impl OpenAI {
         embedding_dimensions: Option<u32>,
         tools: Option<Vec<Tool>>,
         tool_choice: Option<ToolChoice>,
+        normalize_response: Option<bool>,
         reasoning_effort: Option<String>,
         json_schema: Option<StructuredOutputFormat>,
         voice: Option<String>,
@@ -235,6 +236,7 @@ impl OpenAI {
                 json_schema,
                 voice,
                 None, // parallel_tool_calls
+                normalize_response,
                 embedding_encoding_format,
                 embedding_dimensions,
             ),
@@ -528,7 +530,10 @@ impl ChatProvider for OpenAI {
                 raw_response: error_text,
             });
         }
-        Ok(create_sse_stream(response))
+        Ok(create_sse_stream(
+            response,
+            self.provider.normalize_response,
+        ))
     }
 }
 

--- a/src/backends/openrouter.rs
+++ b/src/backends/openrouter.rs
@@ -49,6 +49,7 @@ impl OpenRouter {
         reasoning_effort: Option<String>,
         json_schema: Option<StructuredOutputFormat>,
         parallel_tool_calls: Option<bool>,
+        normalize_response: Option<bool>,
     ) -> Self {
         OpenAICompatibleProvider::<OpenRouterConfig>::new(
             api_key,
@@ -66,6 +67,7 @@ impl OpenRouter {
             json_schema,
             None, // voice - not supported by OpenRouter
             parallel_tool_calls,
+            normalize_response,
             None, // embedding_encoding_format - not supported by OpenRouter
             None, // embedding_dimensions - not supported by OpenRouter
         )

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -141,6 +141,8 @@ pub struct LLMBuilder {
     tool_choice: Option<ToolChoice>,
     /// Enable parallel tool use
     enable_parallel_tool_use: Option<bool>,
+    /// Increase response consistency by normalizing output, e.g. for streaming tool calls
+    normalize_response: Option<bool>,
     /// Enable reasoning
     reasoning: Option<bool>,
     /// Enable reasoning effort
@@ -275,6 +277,12 @@ impl LLMBuilder {
         note = "This method is deprecated and will be removed in a future release. Streaming is defined by the function used (e.g. `chat_stream`)"
     )]
     pub fn stream(self, _stream: bool) -> Self {
+        self
+    }
+
+    /// Sets the request timeout in seconds.
+    pub fn normalize_response(mut self, normalize_response: bool) -> Self {
+        self.normalize_response = Some(normalize_response);
         self
     }
 
@@ -651,6 +659,7 @@ impl LLMBuilder {
                         self.embedding_dimensions,
                         tools,
                         tool_choice,
+                        self.normalize_response,
                         self.reasoning_effort,
                         self.json_schema,
                         self.voice,
@@ -868,6 +877,7 @@ impl LLMBuilder {
                         None, // reasoning_effort
                         self.json_schema,
                         self.enable_parallel_tool_use,
+                        self.normalize_response,
                     );
                     Box::new(groq)
                 }
@@ -901,6 +911,7 @@ impl LLMBuilder {
                         None, // reasoning_effort
                         self.json_schema,
                         self.enable_parallel_tool_use,
+                        self.normalize_response,
                     );
                     Box::new(openrouter)
                 }
@@ -932,6 +943,7 @@ impl LLMBuilder {
                         self.json_schema,
                         None,
                         self.enable_parallel_tool_use,
+                        self.normalize_response,
                         self.embedding_encoding_format,
                         self.embedding_dimensions,
                     );
@@ -965,6 +977,7 @@ impl LLMBuilder {
                         self.reasoning_effort,
                         self.json_schema,
                         self.enable_parallel_tool_use,
+                        self.normalize_response,
                     );
                     Box::new(mistral)
                 }


### PR DESCRIPTION
When streaming tool call some providers will stream the tool call bit by bit (function name, then arguments string token by token, e.g. Mistral/Groq), while other will send the complete tool call as 1 chunk (e.g. OpenAI/OpenRouter). 

This commit introduces `.normalize_response(true)` when building the `LLMBackend` that will normalize stream response for OpenAI Compatible APIs (including OpenAI). 

Currently this makes sure that when streaming a tool call the complete tool call is sent back as one chunk, making it easier to parse by client (and usually you don't gain much from streaming a tool call bit by bit, that will enable you to show the function name before arguments on a UI for example, but that will require a lot more code to handle)

The name is generic so it can be reused for other normalization efforts (this can be changed if you prefer to have separate fields for different normalization effort)

I also made normalization default since one of this crate goal is to "unify" LLM providers (personally I would expect getting normalized response by default, and see handling of different type of responses as a more advanced feature), but feel free to change 