### PR TITLE
feat: add runtime extra HTTP headers support

### DIFF
--- a/src/backends/cohere.rs
+++ b/src/backends/cohere.rs
@@ -76,6 +76,7 @@ impl Cohere {
             normalize_response,
             embedding_encoding_format,
             embedding_dimensions,
+            None, // extra_headers - not exposed via Cohere wrapper
         )
     }
 }

--- a/src/backends/groq.rs
+++ b/src/backends/groq.rs
@@ -87,6 +87,7 @@ impl Groq {
             normalize_response,
             None, // embedding_encoding_format - not supported by Groq
             None, // embedding_dimensions - not supported by Groq
+            None, // extra_headers - not exposed via Groq wrapper
         )
     }
 }

--- a/src/backends/huggingface.rs
+++ b/src/backends/huggingface.rs
@@ -73,6 +73,7 @@ impl HuggingFace {
             normalize_response,
             None, // embedding_encoding_format
             None, // embedding_dimensions
+            None, // extra_headers - not exposed via HuggingFace wrapper
         )
     }
 }

--- a/src/backends/mistral.rs
+++ b/src/backends/mistral.rs
@@ -76,6 +76,7 @@ impl Mistral {
             normalize_response,
             embedding_encoding_format,
             embedding_dimensions,
+            None, // extra_headers - not exposed via Mistral wrapper
         )
     }
 }

--- a/src/backends/openai.rs
+++ b/src/backends/openai.rs
@@ -216,6 +216,7 @@ impl OpenAI {
         web_search_user_location_approximate_country: Option<String>,
         web_search_user_location_approximate_city: Option<String>,
         web_search_user_location_approximate_region: Option<String>,
+        extra_headers: Option<std::collections::HashMap<String, String>>,
     ) -> Result<Self, LLMError> {
         let api_key_str = api_key.into();
         if api_key_str.is_empty() {
@@ -242,6 +243,7 @@ impl OpenAI {
                 normalize_response,
                 embedding_encoding_format,
                 embedding_dimensions,
+                extra_headers,
             ),
             enable_web_search: enable_web_search.unwrap_or(false),
             web_search_context_size,
@@ -340,6 +342,12 @@ impl ChatProvider for OpenAI {
             .post(url)
             .bearer_auth(&self.provider.api_key)
             .json(&body);
+        // Add runtime extra headers
+        if let Some(headers) = &self.provider.extra_headers {
+            for (key, value) in headers {
+                request = request.header(key, value);
+            }
+        }
         if log::log_enabled!(log::Level::Trace) {
             if let Ok(json) = serde_json::to_string(&body) {
                 log::trace!("OpenAI request payload: {}", json);
@@ -475,6 +483,12 @@ impl ChatProvider for OpenAI {
             .post(url)
             .bearer_auth(&self.provider.api_key)
             .json(&body);
+        // Add runtime extra headers
+        if let Some(headers) = &self.provider.extra_headers {
+            for (key, value) in headers {
+                request = request.header(key, value);
+            }
+        }
         if let Some(timeout) = self.provider.timeout_seconds {
             request = request.timeout(std::time::Duration::from_secs(timeout));
         }
@@ -690,6 +704,13 @@ impl OpenAI {
             .post(url)
             .bearer_auth(&self.provider.api_key)
             .json(&body);
+
+        // Add runtime extra headers
+        if let Some(headers) = &self.provider.extra_headers {
+            for (key, value) in headers {
+                request = request.header(key, value);
+            }
+        }
 
         if log::log_enabled!(log::Level::Trace) {
             if let Ok(json) = serde_json::to_string(&body) {

--- a/src/backends/openrouter.rs
+++ b/src/backends/openrouter.rs
@@ -73,6 +73,7 @@ impl OpenRouter {
             normalize_response,
             None, // embedding_encoding_format - not supported by OpenRouter
             None, // embedding_dimensions - not supported by OpenRouter
+            None, // extra_headers - not exposed via OpenRouter wrapper
         )
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -198,6 +198,8 @@ pub struct LLMBuilder {
     resilient_max_delay_ms: Option<u64>,
     /// Resilience: jitter toggle
     resilient_jitter: Option<bool>,
+    /// Extra HTTP headers to include in all requests
+    extra_headers: Option<std::collections::HashMap<String, String>>,
 }
 
 impl LLMBuilder {
@@ -400,6 +402,28 @@ impl LLMBuilder {
     pub fn extra_body(mut self, extra_body: impl serde::Serialize) -> Self {
         let value = serde_json::to_value(extra_body).ok();
         self.extra_body = value;
+        self
+    }
+
+    /// Set extra HTTP headers to include in all requests.
+    ///
+    /// Useful for custom authentication (e.g., Cloudflare Access tokens).
+    ///
+    /// # Example
+    /// ```
+    /// use std::collections::HashMap;
+    /// use llm::builder::LLMBuilder;
+    ///
+    /// let headers = HashMap::from([
+    ///     ("CF-Access-Client-Id".to_string(), "my-client-id".to_string()),
+    ///     ("CF-Access-Client-Secret".to_string(), "my-secret".to_string()),
+    /// ]);
+    ///
+    /// let builder = LLMBuilder::new()
+    ///     .extra_headers(headers);
+    /// ```
+    pub fn extra_headers(mut self, headers: std::collections::HashMap<String, String>) -> Self {
+        self.extra_headers = Some(headers);
         self
     }
 
@@ -683,6 +707,7 @@ impl LLMBuilder {
                         self.openai_web_search_user_location_approximate_country,
                         self.openai_web_search_user_location_approximate_city,
                         self.openai_web_search_user_location_approximate_region,
+                        self.extra_headers,
                     )?)
                 }
             }
@@ -963,6 +988,7 @@ impl LLMBuilder {
                         self.normalize_response,
                         self.embedding_encoding_format,
                         self.embedding_dimensions,
+                        self.extra_headers,
                     );
                     Box::new(cohere)
                 }


### PR DESCRIPTION
## Summary
- Adds `extra_headers()` builder method to `LLMBuilder` for runtime-configurable HTTP headers
- Enables use cases like Cloudflare Access authentication tokens for secure vLLM endpoints
- Headers are applied to all HTTP requests made by OpenAI-compatible providers

**Note:** This PR is based on #94 (streaming with tools support) because the new `chat_stream_with_tools()` methods also make HTTP requests that need extra headers support.

## Use Case
```rust
use std::collections::HashMap;
use llm::builder::LLMBuilder;

let headers = HashMap::from([
    ("CF-Access-Client-Id".to_string(), "my-client-id".to_string()),
    ("CF-Access-Client-Secret".to_string(), "my-secret".to_string()),
]);

let llm = LLMBuilder::new()
    .backend(LLMBackend::OpenAI)
    .base_url("https://vllm.example.com/v1/")
    .api_key("not-needed")
    .model("meta-llama/Llama-3.1-8B-Instruct")
    .extra_headers(headers)
    .build()?;
```

## Changes
- `src/builder.rs` - Added `extra_headers` field and builder method
- `src/providers/openai_compatible.rs` - Store and apply extra headers in requests
- `src/backends/openai.rs` - Pass extra headers to provider
- Other backends updated to pass `None` for compatibility

## Test plan
- [x] Build passes
- [x] Clippy passes
- [x] Unit tests for extra_headers functionality added
- [ ] Manual testing with Cloudflare-protected endpoint