### PR TITLE
Fix base_url joining bug by normalizing trailing slash in builder

### DIFF
--- a/src/providers/openai_compatible.rs
+++ b/src/providers/openai_compatible.rs
@@ -327,7 +327,7 @@ impl<T: OpenAIProviderConfig> OpenAICompatibleProvider<T> {
         };
         Self {
             api_key: api_key.into(),
-            base_url: Url::parse(&base_url.unwrap_or_else(|| T::DEFAULT_BASE_URL.to_owned()))
+            base_url: Url::parse(&format!("{}/", base_url.unwrap_or_else(|| T::DEFAULT_BASE_URL.to_owned()).trim_end_matches("/")))
                 .expect("Failed to parse base URL"),
             model: model.unwrap_or_else(|| T::DEFAULT_MODEL.to_string()),
             max_tokens,


### PR DESCRIPTION
Many OpenAI-compatible providers document `base_url` without a trailing slash, for example:

```python
from openai import OpenAI

client = OpenAI(
base_url="https://openrouter.ai/api/v1",
api_key="<OPENROUTER_API_KEY>",
)
```

When developers copy these examples into our configuration, the missing trailing / can interact poorly with URL resolution. 

Specifically, when we construct request URLs via Url::join, a base_url that does not end with / may cause the last path segment to be treated as a “file” and replaced, yielding an incorrect endpoint (e.g., https://openrouter.ai/api/v1 + join("chat/completions") → https://openrouter.ai/api/chat/completions).

Normalize `base_url` in the builder so it always ends with exactly one '/'.

This improves robustness and makes it easier for users migrating from other platforms/languages (e.g. the Python example).