### PR TITLE
Enable configuring base URL for Anthropic provider

### DIFF
--- a/src/backends/anthropic.rs
+++ b/src/backends/anthropic.rs
@@ -726,7 +726,7 @@ impl ChatProvider for Anthropic {
             thinking,
         };
 
-        let url = format!("{}/messages", self.config.base_url);
+        let url = format!("{}/messages", self.config.base_url.trim_end_matches('/'));
         let mut request = self
             .client
             .post(&url)

--- a/src/bin/llm-cli/conversation/convert.rs
+++ b/src/bin/llm-cli/conversation/convert.rs
@@ -53,6 +53,13 @@ pub fn to_chat_messages(messages: &[ConversationMessage]) -> Vec<ChatMessage> {
                 i += 1;
             }
             MessageKind::Text(content) => {
+                // Skip empty messages (placeholders that haven't been filled yet)
+                // These are typically assistant messages with Streaming or Pending state
+                if content.trim().is_empty() {
+                    i += 1;
+                    continue;
+                }
+
                 match message.role {
                     MessageRole::User => {
                         result.push(ChatMessage::user().content(content).build());

--- a/src/bin/llm-cli/runtime/controller/input/mod.rs
+++ b/src/bin/llm-cli/runtime/controller/input/mod.rs
@@ -39,9 +39,20 @@ pub fn handle_tick(controller: &mut AppController) -> bool {
 
 fn handle_paste_event(controller: &mut AppController, text: String) -> bool {
     if let OverlayState::Onboarding(state) = &mut controller.state.overlay {
-        state.api_key.push_str(&text);
-        controller.state.paste_detector.record_paste(Instant::now());
-        return true;
+        use crate::runtime::OnboardingStep;
+        match state.step {
+            OnboardingStep::ApiKey => {
+                state.api_key.push_str(&text);
+                controller.state.paste_detector.record_paste(Instant::now());
+                return true;
+            }
+            OnboardingStep::BaseUrl => {
+                state.base_url.push_str(&text);
+                controller.state.paste_detector.record_paste(Instant::now());
+                return true;
+            }
+            _ => {}
+        }
     }
     helpers::handle_paste(controller, text)
 }

--- a/src/bin/llm-cli/runtime/controller/input/overlay_keys/handlers/onboarding.rs
+++ b/src/bin/llm-cli/runtime/controller/input/overlay_keys/handlers/onboarding.rs
@@ -10,6 +10,7 @@ pub(super) fn handle_onboarding(state: &mut OnboardingState, key: KeyEvent) -> O
         OnboardingStep::Welcome => handle_onboarding_welcome(state, key),
         OnboardingStep::Provider => handle_onboarding_provider(state, key),
         OnboardingStep::ApiKey => handle_onboarding_key(state, key),
+        OnboardingStep::BaseUrl => handle_onboarding_base_url(state, key),
         OnboardingStep::Preferences => handle_onboarding_preferences(state, key),
         OnboardingStep::Confirm => handle_onboarding_confirm(state, key),
     }
@@ -72,6 +73,36 @@ fn handle_onboarding_key(state: &mut OnboardingState, key: KeyEvent) -> OverlayR
             } else {
                 state.next_step();
             }
+            OverlayResult::action(OverlayAction::Handled)
+        }
+        _ => OverlayResult::action(OverlayAction::None),
+    }
+}
+
+fn handle_onboarding_base_url(state: &mut OnboardingState, key: KeyEvent) -> OverlayResult {
+    match key.code {
+        KeyCode::Esc => {
+            state.prev_step();
+            OverlayResult::action(OverlayAction::Handled)
+        }
+        KeyCode::Backspace => {
+            state.error = None;
+            state.base_url.pop();
+            OverlayResult::action(OverlayAction::Handled)
+        }
+        KeyCode::Char(ch) => {
+            state.error = None;
+            state.base_url.push(ch);
+            OverlayResult::action(OverlayAction::Handled)
+        }
+        KeyCode::Enter => {
+            // If empty and a default exists, use the default
+            if state.base_url.trim().is_empty() {
+                if let Some(default_url) = state.default_base_url() {
+                    state.base_url = default_url.to_string();
+                }
+            }
+            state.next_step();
             OverlayResult::action(OverlayAction::Handled)
         }
         _ => OverlayResult::action(OverlayAction::None),

--- a/src/bin/llm-cli/runtime/controller/onboarding.rs
+++ b/src/bin/llm-cli/runtime/controller/onboarding.rs
@@ -61,6 +61,23 @@ fn apply_onboarding_config(
     controller.state.config.default_provider = Some(provider.id.as_str().to_string());
     controller.state.config.ui.navigation_mode = state.mode;
     controller.state.config.ui.theme = state.theme.clone();
+
+    // Save provider config (backend and base_url)
+    let provider_config = controller
+        .state
+        .config
+        .providers
+        .entry(provider.id.as_str().to_string())
+        .or_default();
+
+    // Always set the backend field to ensure it's correctly configured
+    provider_config.backend = Some(provider.backend.to_string());
+
+    // Save base_url if provided
+    if !state.base_url.trim().is_empty() {
+        provider_config.base_url = Some(state.base_url.trim().to_string());
+    }
+
     if let Err(err) = save_config(&controller.state.config, &controller.config_paths) {
         controller.set_status(AppStatus::Error(format!("save config: {err}")));
         return Err(format!("save config: {err}"));

--- a/src/bin/llm-cli/runtime/overlay/onboarding.rs
+++ b/src/bin/llm-cli/runtime/overlay/onboarding.rs
@@ -8,6 +8,7 @@ pub enum OnboardingStep {
     Welcome,
     Provider,
     ApiKey,
+    BaseUrl,
     Preferences,
     Confirm,
 }
@@ -25,6 +26,7 @@ pub struct OnboardingState {
     pub providers: Vec<OnboardingProvider>,
     pub selected: usize,
     pub api_key: String,
+    pub base_url: String,
     pub mode: NavigationMode,
     pub theme: String,
     pub error: Option<String>,
@@ -37,6 +39,7 @@ impl OnboardingState {
             providers,
             selected: 0,
             api_key: String::new(),
+            base_url: String::new(),
             mode,
             theme,
             error: None,
@@ -47,7 +50,8 @@ impl OnboardingState {
         self.step = match self.step {
             OnboardingStep::Welcome => OnboardingStep::Provider,
             OnboardingStep::Provider => OnboardingStep::ApiKey,
-            OnboardingStep::ApiKey => OnboardingStep::Preferences,
+            OnboardingStep::ApiKey => OnboardingStep::BaseUrl,
+            OnboardingStep::BaseUrl => OnboardingStep::Preferences,
             OnboardingStep::Preferences => OnboardingStep::Confirm,
             OnboardingStep::Confirm => OnboardingStep::Confirm,
         };
@@ -59,7 +63,8 @@ impl OnboardingState {
             OnboardingStep::Welcome => OnboardingStep::Welcome,
             OnboardingStep::Provider => OnboardingStep::Welcome,
             OnboardingStep::ApiKey => OnboardingStep::Provider,
-            OnboardingStep::Preferences => OnboardingStep::ApiKey,
+            OnboardingStep::BaseUrl => OnboardingStep::ApiKey,
+            OnboardingStep::Preferences => OnboardingStep::BaseUrl,
             OnboardingStep::Confirm => OnboardingStep::Preferences,
         };
         self.error = None;
@@ -83,5 +88,14 @@ impl OnboardingState {
 
     pub fn set_error(&mut self, message: impl Into<String>) {
         self.error = Some(message.into());
+    }
+
+    pub fn default_base_url(&self) -> Option<&str> {
+        self.selected_provider().and_then(|provider| {
+            match provider.backend {
+                LLMBackend::Anthropic => Some("https://api.anthropic.com/v1"),
+                _ => None,
+            }
+        })
     }
 }

--- a/src/bin/llm-cli/ui/overlay/onboarding.rs
+++ b/src/bin/llm-cli/ui/overlay/onboarding.rs
@@ -36,6 +36,7 @@ fn step_title(step: OnboardingStep) -> &'static str {
         OnboardingStep::Welcome => "Welcome",
         OnboardingStep::Provider => "Choose Provider",
         OnboardingStep::ApiKey => "API Key",
+        OnboardingStep::BaseUrl => "Base URL",
         OnboardingStep::Preferences => "Preferences",
         OnboardingStep::Confirm => "Confirm",
     }
@@ -46,6 +47,7 @@ fn build_lines(state: &OnboardingState, theme: &Theme) -> Vec<Line<'static>> {
         OnboardingStep::Welcome => welcome_lines(),
         OnboardingStep::Provider => provider_lines(state),
         OnboardingStep::ApiKey => api_key_lines(state),
+        OnboardingStep::BaseUrl => base_url_lines(state),
         OnboardingStep::Preferences => preference_lines(state),
         OnboardingStep::Confirm => confirm_lines(state),
     };
@@ -90,6 +92,31 @@ fn api_key_lines(state: &OnboardingState) -> Vec<Line<'static>> {
     ]
 }
 
+fn base_url_lines(state: &OnboardingState) -> Vec<Line<'static>> {
+    let name = state
+        .selected_provider()
+        .map(|provider| provider.name.clone())
+        .unwrap_or_else(|| "provider".to_string());
+
+    let default_info = if let Some(default_url) = state.default_base_url() {
+        format!("(default: {})", default_url)
+    } else {
+        "(optional)".to_string()
+    };
+
+    let display_url = if state.base_url.is_empty() {
+        "<empty>".to_string()
+    } else {
+        state.base_url.clone()
+    };
+
+    vec![
+        Line::from(format!("Enter Base URL for {name} {}:", default_info)),
+        Line::from(display_url),
+        Line::from("Leave empty to use default. Press Enter to continue, Esc to go back."),
+    ]
+}
+
 fn preference_lines(state: &OnboardingState) -> Vec<Line<'static>> {
     vec![
         Line::from("Preferences:"),
@@ -104,11 +131,19 @@ fn confirm_lines(state: &OnboardingState) -> Vec<Line<'static>> {
         .selected_provider()
         .map(|p| p.id.as_str().to_string())
         .unwrap_or_else(|| "-".to_string());
-    vec![
+
+    let mut lines = vec![
         Line::from("Ready to go!"),
         Line::from(format!("Provider: {provider}")),
-        Line::from(format!("Mode: {:?}", state.mode)),
-        Line::from(format!("Theme: {}", state.theme)),
-        Line::from("Press Enter to finish."),
-    ]
+    ];
+
+    if !state.base_url.is_empty() {
+        lines.push(Line::from(format!("Base URL: {}", state.base_url)));
+    }
+
+    lines.push(Line::from(format!("Mode: {:?}", state.mode)));
+    lines.push(Line::from(format!("Theme: {}", state.theme)));
+    lines.push(Line::from("Press Enter to finish."));
+
+    lines
 }

--- a/src/builder/backend.rs
+++ b/src/builder/backend.rs
@@ -1,3 +1,5 @@
+use std::fmt::Formatter;
+
 use crate::error::LLMError;
 
 /// Supported LLM backend providers.
@@ -44,5 +46,28 @@ impl std::str::FromStr for LLMBackend {
                 "Unknown LLM backend: {s}"
             ))),
         }
+    }
+}
+
+impl std::fmt::Display for LLMBackend {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            LLMBackend::OpenAI => "openai",
+            LLMBackend::Anthropic => "anthropic",
+            LLMBackend::DeepSeek => "deepseek",
+            LLMBackend::XAI => "xai",
+            LLMBackend::Google => "google",
+            LLMBackend::Groq => "groq",
+            LLMBackend::AzureOpenAI => "azure-openai",
+            LLMBackend::Cohere => "cohere",
+            LLMBackend::Mistral => "mistral",
+            LLMBackend::OpenRouter => "openrouter",
+            LLMBackend::HuggingFace => "huggingface",
+            LLMBackend::Ollama => "ollama",
+            LLMBackend::Phind => "phind",
+            LLMBackend::ElevenLabs => "elevenlabs",
+            LLMBackend::AwsBedrock => "aws-bedrock",
+        };
+        write!(f, "{name}")
     }
 }

--- a/src/builder/build/backends/anthropic.rs
+++ b/src/builder/build/backends/anthropic.rs
@@ -22,6 +22,7 @@ pub(super) fn build_anthropic(
 
     let provider = crate::backends::anthropic::Anthropic::new(
         api_key,
+        state.base_url.take(),
         state.model.take(),
         state.max_tokens,
         state.temperature,


### PR DESCRIPTION
1. Enable configuring base URL for Anthropic provider
2. Add a new onboarding step to configure base URL in TUI app.
3. Add `backend` field in `config.toml` after onboarding so newly configured provider can be other than OpenAI
4. Filter empty messages before sending in TUI, which causes Anthropic API error.
5. Fix tool use in TUI with Anthropic provider. Previously the tool result messages were sent with wrong role and got rejected.