### PR TITLE
feat: add cache_control support to tools for Anthropic and Bedrock

### DIFF
--- a/src/backends/anthropic.rs
+++ b/src/backends/anthropic.rs
@@ -81,6 +81,8 @@ struct AnthropicTool<'a> {
     description: &'a str,
     #[serde(rename = "input_schema")]
     schema: &'a serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cache_control: Option<&'a serde_json::Value>,
 }
 
 /// Configuration for the thinking feature
@@ -468,6 +470,7 @@ impl Anthropic {
                     name: &tool.function.name,
                     description: &tool.function.description,
                     schema: &tool.function.parameters,
+                    cache_control: tool.cache_control.as_ref(),
                 })
                 .collect::<Vec<_>>()
         });
@@ -1556,5 +1559,80 @@ data: {"type": "ping"}
         let mut tool_states = HashMap::new();
         let result = parse_anthropic_sse_chunk_with_tools(chunk, &mut tool_states).unwrap();
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_anthropic_tool_serialization_without_cache_control() {
+        let schema = serde_json::json!({"type": "object", "properties": {}});
+        let tool = AnthropicTool {
+            name: "my_tool",
+            description: "desc",
+            schema: &schema,
+            cache_control: None,
+        };
+
+        let json = serde_json::to_value(&tool).unwrap();
+        assert_eq!(json.get("name").unwrap(), "my_tool");
+        assert!(json.get("cache_control").is_none());
+    }
+
+    #[test]
+    fn test_anthropic_tool_serialization_with_cache_control() {
+        let schema = serde_json::json!({"type": "object", "properties": {}});
+        let cc = serde_json::json!({"type": "ephemeral"});
+        let tool = AnthropicTool {
+            name: "my_tool",
+            description: "desc",
+            schema: &schema,
+            cache_control: Some(&cc),
+        };
+
+        let json = serde_json::to_value(&tool).unwrap();
+        assert_eq!(
+            json.get("cache_control").unwrap(),
+            &serde_json::json!({"type": "ephemeral"})
+        );
+    }
+
+    #[test]
+    fn test_prepare_tools_maps_cache_control() {
+        let tools = vec![Tool {
+            tool_type: "function".to_string(),
+            function: crate::chat::FunctionTool {
+                name: "get_weather".to_string(),
+                description: "Get weather".to_string(),
+                parameters: serde_json::json!({"type": "object", "properties": {}}),
+            },
+            cache_control: Some(serde_json::json!({"type": "ephemeral"})),
+        }];
+
+        let (anthropic_tools, _) =
+            Anthropic::prepare_tools_and_choice(Some(&tools), None, &None);
+
+        let anthropic_tools = anthropic_tools.expect("tools should be present");
+        assert_eq!(anthropic_tools.len(), 1);
+        assert_eq!(
+            anthropic_tools[0].cache_control,
+            Some(&serde_json::json!({"type": "ephemeral"}))
+        );
+    }
+
+    #[test]
+    fn test_prepare_tools_none_cache_control() {
+        let tools = vec![Tool {
+            tool_type: "function".to_string(),
+            function: crate::chat::FunctionTool {
+                name: "get_weather".to_string(),
+                description: "Get weather".to_string(),
+                parameters: serde_json::json!({"type": "object", "properties": {}}),
+            },
+            cache_control: None,
+        }];
+
+        let (anthropic_tools, _) =
+            Anthropic::prepare_tools_and_choice(Some(&tools), None, &None);
+
+        let anthropic_tools = anthropic_tools.expect("tools should be present");
+        assert!(anthropic_tools[0].cache_control.is_none());
     }
 }

--- a/src/backends/aws/mod.rs
+++ b/src/backends/aws/mod.rs
@@ -10,9 +10,9 @@ use async_trait::async_trait;
 use aws_config::BehaviorVersion;
 use aws_sdk_bedrockruntime::{
     types::{
-        ContentBlock, ContentBlockDelta, ConversationRole, ConverseStreamOutput, Message,
-        SystemContentBlock, Tool, ToolConfiguration, ToolInputSchema, ToolResultBlock,
-        ToolResultContentBlock, ToolUseBlock,
+        CachePointBlock, CachePointType, ContentBlock, ContentBlockDelta, ConversationRole,
+        ConverseStreamOutput, Message, SystemContentBlock, Tool, ToolConfiguration,
+        ToolInputSchema, ToolResultBlock, ToolResultContentBlock, ToolUseBlock,
     },
     Client as BedrockClient,
 };
@@ -612,6 +612,13 @@ impl BedrockBackend {
         // Tools
         let mut bedrock_tools = Vec::new();
 
+        // Check if any tool has cache_control before consuming request.tools
+        let request_tools_need_cache = request
+            .tools
+            .as_ref()
+            .map(|tools| tools.iter().any(|t| t.cache_control.is_some()))
+            .unwrap_or(false);
+
         if let Some(tools) = request.tools {
             for tool in tools {
                 bedrock_tools.push(self.convert_tool(&tool)?);
@@ -647,6 +654,27 @@ impl BedrockBackend {
             for tool in tools {
                 bedrock_tools.push(self.convert_llm_tool(tool)?);
             }
+        }
+
+        // Append a CachePoint if any tool has cache_control set
+        let self_tools_need_cache = self
+            .tools
+            .as_ref()
+            .map(|tools| tools.iter().any(|t| t.cache_control.is_some()))
+            .unwrap_or(false);
+
+        if (request_tools_need_cache || self_tools_need_cache) && !bedrock_tools.is_empty() {
+            bedrock_tools.push(Tool::CachePoint(
+                CachePointBlock::builder()
+                    .r#type(CachePointType::Default)
+                    .build()
+                    .map_err(|e| {
+                        BedrockError::InvalidRequest(format!(
+                            "Failed to build cache point: {:?}",
+                            e
+                        ))
+                    })?,
+            ));
         }
 
         let effective_tool_choice = tool_choice.unwrap_or(LlmToolChoice::Auto);
@@ -1131,6 +1159,7 @@ impl ChatProvider for BedrockBackend {
                     name: t.function.name.clone(),
                     description: t.function.description.clone(),
                     input_schema: t.function.parameters.clone(),
+                    cache_control: t.cache_control.clone(),
                 })
                 .collect();
 
@@ -1275,5 +1304,115 @@ streaming = true
             overrides.supports(&model, ModelCapability::Streaming),
             Some(true)
         );
+    }
+
+    #[test]
+    fn test_prepare_chat_request_no_cache_point_without_cache_control() {
+        let backend = BedrockBackend::new(
+            "us-east-1".to_string(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let tools = vec![ToolDefinition {
+            name: "get_weather".to_string(),
+            description: "Get weather".to_string(),
+            input_schema: serde_json::json!({"type": "object", "properties": {}}),
+            cache_control: None,
+        }];
+
+        let request = ChatRequest::new(vec![ChatMessage::user("hello")]).with_tools(tools);
+        let prepared = backend.prepare_chat_request(request).unwrap();
+
+        let tool_config = prepared.tool_config.expect("tool_config should be present");
+        let tools = tool_config.tools();
+        // Should only have the ToolSpec, no CachePoint
+        assert_eq!(tools.len(), 1);
+        assert!(matches!(tools[0], Tool::ToolSpec(_)));
+    }
+
+    #[test]
+    fn test_prepare_chat_request_appends_cache_point_with_cache_control() {
+        let backend = BedrockBackend::new(
+            "us-east-1".to_string(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let tools = vec![ToolDefinition {
+            name: "get_weather".to_string(),
+            description: "Get weather".to_string(),
+            input_schema: serde_json::json!({"type": "object", "properties": {}}),
+            cache_control: Some(serde_json::json!({"type": "ephemeral"})),
+        }];
+
+        let request = ChatRequest::new(vec![ChatMessage::user("hello")]).with_tools(tools);
+        let prepared = backend.prepare_chat_request(request).unwrap();
+
+        let tool_config = prepared.tool_config.expect("tool_config should be present");
+        let tools = tool_config.tools();
+        // Should have ToolSpec + CachePoint
+        assert_eq!(tools.len(), 2);
+        assert!(matches!(tools[0], Tool::ToolSpec(_)));
+        assert!(matches!(tools[1], Tool::CachePoint(_)));
+    }
+
+    #[test]
+    fn test_prepare_chat_request_cache_point_from_self_tools() {
+        let llm_tools = vec![LlmTool {
+            tool_type: "function".to_string(),
+            function: crate::chat::FunctionTool {
+                name: "search".to_string(),
+                description: "Search".to_string(),
+                parameters: serde_json::json!({"type": "object", "properties": {}}),
+            },
+            cache_control: Some(serde_json::json!({"type": "ephemeral"})),
+        }];
+
+        let backend = BedrockBackend::new(
+            "us-east-1".to_string(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(llm_tools),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let request = ChatRequest::new(vec![ChatMessage::user("hello")]);
+        let prepared = backend.prepare_chat_request(request).unwrap();
+
+        let tool_config = prepared.tool_config.expect("tool_config should be present");
+        let tools = tool_config.tools();
+        // Should have ToolSpec + CachePoint
+        assert_eq!(tools.len(), 2);
+        assert!(matches!(tools[0], Tool::ToolSpec(_)));
+        assert!(matches!(tools[1], Tool::CachePoint(_)));
     }
 }

--- a/src/backends/aws/types.rs
+++ b/src/backends/aws/types.rs
@@ -250,6 +250,10 @@ pub struct ToolDefinition {
 
     /// JSON schema for the tool's input parameters
     pub input_schema: Value,
+
+    /// Optional cache control directive for prompt caching
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<Value>,
 }
 
 /// Request for text embeddings

--- a/src/builder/tools.rs
+++ b/src/builder/tools.rs
@@ -115,6 +115,7 @@ pub struct FunctionBuilder {
     parameters: Vec<ParamBuilder>,
     required: Vec<String>,
     raw_schema: Option<serde_json::Value>,
+    cache_control: Option<serde_json::Value>,
 }
 
 impl FunctionBuilder {
@@ -126,6 +127,7 @@ impl FunctionBuilder {
             parameters: Vec::new(),
             required: Vec::new(),
             raw_schema: None,
+            cache_control: None,
         }
     }
 
@@ -153,6 +155,12 @@ impl FunctionBuilder {
         self
     }
 
+    /// Sets cache control for this tool (e.g. `json!({"type": "ephemeral"})` for Anthropic prompt caching).
+    pub fn cache_control(mut self, cache_control: serde_json::Value) -> Self {
+        self.cache_control = Some(cache_control);
+        self
+    }
+
     /// Builds the function tool.
     fn build(self) -> Tool {
         let FunctionBuilder {
@@ -161,6 +169,7 @@ impl FunctionBuilder {
             parameters,
             required,
             raw_schema,
+            cache_control,
         } = self;
 
         let parameters = build_parameters(raw_schema, parameters, required);
@@ -172,7 +181,60 @@ impl FunctionBuilder {
                 description,
                 parameters,
             },
+            cache_control,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn function_builder_without_cache_control() {
+        let tool = FunctionBuilder::new("my_tool")
+            .description("A test tool")
+            .build();
+
+        assert_eq!(tool.tool_type, "function");
+        assert_eq!(tool.function.name, "my_tool");
+        assert!(tool.cache_control.is_none());
+    }
+
+    #[test]
+    fn function_builder_with_cache_control() {
+        let tool = FunctionBuilder::new("my_tool")
+            .description("A test tool")
+            .cache_control(serde_json::json!({"type": "ephemeral"}))
+            .build();
+
+        assert_eq!(tool.function.name, "my_tool");
+        let cc = tool.cache_control.expect("cache_control should be set");
+        assert_eq!(cc, serde_json::json!({"type": "ephemeral"}));
+    }
+
+    #[test]
+    fn tool_serialization_omits_cache_control_when_none() {
+        let tool = FunctionBuilder::new("my_tool")
+            .description("desc")
+            .build();
+
+        let json = serde_json::to_value(&tool).unwrap();
+        assert!(json.get("cache_control").is_none());
+    }
+
+    #[test]
+    fn tool_serialization_includes_cache_control_when_set() {
+        let tool = FunctionBuilder::new("my_tool")
+            .description("desc")
+            .cache_control(serde_json::json!({"type": "ephemeral"}))
+            .build();
+
+        let json = serde_json::to_value(&tool).unwrap();
+        assert_eq!(
+            json.get("cache_control").unwrap(),
+            &serde_json::json!({"type": "ephemeral"})
+        );
     }
 }
 

--- a/src/chat/tool.rs
+++ b/src/chat/tool.rs
@@ -63,6 +63,9 @@ pub struct Tool {
     pub tool_type: String,
     /// The function definition if this is a function tool
     pub function: FunctionTool,
+    /// Optional cache control directive (e.g. `{"type": "ephemeral"}` for Anthropic prompt caching)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<Value>,
 }
 
 /// Tool choice determines how the LLM uses available tools.


### PR DESCRIPTION
## Summary

- Add optional `cache_control` field to the core `Tool` struct and `FunctionBuilder`, enabling prompt caching on tool definitions
- Wire `cache_control` through Anthropic backend (`AnthropicTool` serialization) for up to 90% cost reduction on cache hits
- Wire `cache_control` through Bedrock backend by appending a `CachePoint` element to the tools array when any tool has `cache_control` set
- Add `cache_control` to Bedrock's `ToolDefinition` so the flag carries through the `ChatRequest` path

## Test plan

- [x] 4 new unit tests for `FunctionBuilder` (builder wiring + serialization with/without `cache_control`)
- [x] 4 new unit tests for Anthropic backend (`AnthropicTool` serialization + `prepare_tools_and_choice` mapping)
- [x] 3 new unit tests for Bedrock backend (`prepare_chat_request` with/without `CachePoint` from request and self tools)
- [x] All 60 existing + new tests pass
- [x] `cargo check` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)