### PR TITLE
Azure openai updates, Bedrock Streaming and dependency hygene

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "actix-utils",
- "base64 0.22.1",
+ "base64",
  "bitflags 2.10.0",
  "brotli",
  "bytes",
@@ -89,13 +89,13 @@ dependencies = [
  "actix-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.2.0",
+ "http 1.4.0",
  "impl-more",
  "pin-project-lite",
- "rustls-native-certs 0.8.3",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tracing",
 ]
@@ -332,7 +332,7 @@ dependencies = [
  "actix-service",
  "actix-tls",
  "actix-utils",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "cfg-if",
  "cookie",
@@ -347,7 +347,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rand 0.9.2",
- "rustls 0.23.20",
+ "rustls 0.23.37",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -366,8 +366,8 @@ dependencies = [
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json 0.61.9",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -375,7 +375,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "http 1.2.0",
+ "http 1.4.0",
  "ring",
  "time",
  "tokio",
@@ -386,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.11"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd362783681b15d136480ad555a099e82ecd8e2d10a841e14dfd0078d67fee3"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -420,23 +420,24 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.10"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c034a1bc1d70e16e7f4e4caf7e9f7693e4c9c24cd91cf17c2a0b21abaebc7c8b"
+checksum = "5fc0651c57e384202e47153c1260b84a9936e19803d747615edf199dc3b98d17"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
  "bytes",
+ "bytes-utils",
  "fastrand",
- "http 0.2.12",
- "http-body 0.4.6",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -445,17 +446,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-bedrockruntime"
-version = "1.104.0"
+version = "1.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1574d1fad8f4bbf71aeb5dbb16653e7db48463f031ae77fdc161621019364d4a"
+checksum = "c710f0b7dbd906047724ec892afc0de0b92c7484ba25f499a91563e0417a96d6"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -463,7 +465,8 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "hyper 0.14.32",
+ "http 1.4.0",
+ "http-body-util",
  "regex-lite",
  "tracing",
 ]
@@ -477,8 +480,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json 0.61.9",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -499,8 +502,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json 0.61.9",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -521,8 +524,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json 0.61.9",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -537,13 +540,13 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.7"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e523e1c4e8e7e8ff219d732988e22bfeae8a1cafdbe6d9eca1546fa080be7c"
+checksum = "b0b660013a6683ab23797778e21f1f854744fdf05f68204b4cca4c8c04b5d1f4"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -551,7 +554,7 @@ dependencies = [
  "hex",
  "hmac",
  "http 0.2.12",
- "http 1.2.0",
+ "http 1.4.0",
  "percent-encoding",
  "sha2",
  "time",
@@ -560,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.7"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee19095c7c4dda59f1697d028ce704c24b2d33c6718790c7f1d5a3015b4107c"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -571,9 +574,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.14"
+version = "0.60.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc12f8b310e38cad85cf3bef45ad236f470717393c613266ce0a89512286b650"
+checksum = "faf09d74e5e32f76b8762da505a3cd59303e367a664ca67295387baa8c1d7548"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -586,7 +589,6 @@ version = "0.62.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
 dependencies = [
- "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -594,7 +596,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 0.2.12",
- "http 1.2.0",
+ "http 1.4.0",
  "http-body 0.4.6",
  "percent-encoding",
  "pin-project-lite",
@@ -603,10 +605,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-http-client"
-version = "1.0.6"
+name = "aws-smithy-http"
+version = "0.63.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f108f1ca850f3feef3009bdcc977be201bca9a91058864d9de0684e64514bee0"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -614,7 +638,7 @@ dependencies = [
  "h2 0.3.27",
  "h2 0.4.12",
  "http 0.2.12",
- "http 1.2.0",
+ "http 1.4.0",
  "http-body 0.4.6",
  "hyper 0.14.32",
  "hyper 1.8.1",
@@ -623,10 +647,11 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.20",
- "rustls-native-certs 0.8.3",
+ "rustls 0.23.37",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
+ "tokio-rustls 0.26.4",
  "tower",
  "tracing",
 ]
@@ -641,10 +666,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-observability"
-version = "0.1.5"
+name = "aws-smithy-json"
+version = "0.62.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f616c3f2260612fe44cede278bafa18e73e6479c4e393e2c4518cf2a9a228a"
+checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
@@ -661,12 +695,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.8.6"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e107ce0783019dbff59b3a244aa0c114e4a8c9d93498af9162608cd5474e796"
+checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
@@ -674,9 +708,10 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.2.0",
+ "http 1.4.0",
  "http-body 0.4.6",
  "http-body 1.0.1",
+ "http-body-util",
  "pin-project-lite",
  "pin-utils",
  "tokio",
@@ -685,15 +720,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.9.3"
+version = "1.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0d43d899f9e508300e587bf582ba54c27a452dd0a9ea294690669138ae14a2"
+checksum = "876ab3c9c29791ba4ba02b780a3049e21ec63dabda09268b175272c3733a79e6"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.2.0",
+ "http 1.4.0",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -702,16 +737,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.3.5"
+version = "1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "905cb13a9895626d49cf2ced759b062d913834c7482c38e49557eac4e6193f01"
+checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
 dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.2.0",
+ "http 1.4.0",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -737,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.11"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d980627d2dd7bfc32a3c025685a033eeab8d365cc840c631ef59d1b8f428164"
+checksum = "47c8323699dd9b3c8d5b3c13051ae9cdef58fd179957c882f8374dd8725962d9"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -759,7 +794,7 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http 1.2.0",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
@@ -792,7 +827,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.2.0",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -803,12 +838,6 @@ dependencies = [
  "tower-service",
  "tracing",
 ]
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -936,9 +965,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytes-utils"
@@ -1834,7 +1863,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.2.0",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -1904,12 +1933,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -1931,18 +1959,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http 1.4.0",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
- "http 1.2.0",
+ "futures-core",
+ "http 1.4.0",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -1994,7 +2022,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2 0.4.12",
- "http 1.2.0",
+ "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -2017,7 +2045,6 @@ dependencies = [
  "hyper 0.14.32",
  "log",
  "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
@@ -2029,14 +2056,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
- "http 1.2.0",
+ "http 1.4.0",
  "hyper 1.8.1",
  "hyper-util",
- "rustls 0.23.20",
- "rustls-native-certs 0.8.3",
+ "rustls 0.23.37",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.4",
  "tower-service",
  "webpki-roots 0.26.11",
 ]
@@ -2059,18 +2086,22 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.2.0",
+ "http 1.4.0",
  "http-body 1.0.1",
  "hyper 1.8.1",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.8",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2341,9 +2372,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
@@ -2435,9 +2466,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.178"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libloading"
@@ -2496,7 +2527,7 @@ dependencies = [
  "aws-sdk-bedrockruntime",
  "aws-smithy-types",
  "axum",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "chrono",
  "clap",
@@ -2509,7 +2540,7 @@ dependencies = [
  "futures",
  "fuzzy-matcher",
  "hound",
- "http 1.2.0",
+ "http 1.4.0",
  "http-body-util",
  "hyper 1.8.1",
  "insta",
@@ -2653,14 +2684,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2673,7 +2704,7 @@ dependencies = [
  "bytes",
  "colored",
  "futures-core",
- "http 1.2.0",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
@@ -3108,7 +3139,7 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "indexmap",
  "quick-xml",
  "serde",
@@ -3276,7 +3307,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.20",
+ "rustls 0.23.37",
  "socket2 0.5.8",
  "thiserror 2.0.12",
  "tokio",
@@ -3294,7 +3325,7 @@ dependencies = [
  "rand 0.8.5",
  "ring",
  "rustc-hash 2.1.1",
- "rustls 0.23.20",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -3488,11 +3519,11 @@ version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.2.0",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
@@ -3509,8 +3540,8 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.20",
- "rustls-pemfile 2.2.0",
+ "rustls 0.23.37",
+ "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3518,7 +3549,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
  "tower-service",
@@ -3649,29 +3680,17 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.20"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe 0.1.5",
- "rustls-pemfile 1.0.4",
- "schannel",
- "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -3684,15 +3703,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework 3.5.1",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -3726,9 +3736,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3756,9 +3766,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -4103,12 +4113,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4515,9 +4525,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
 dependencies = [
  "bytes",
  "libc",
@@ -4525,16 +4535,16 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4563,11 +4573,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.1"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.20",
+ "rustls 0.23.37",
  "tokio",
 ]
 
@@ -4597,9 +4607,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4673,7 +4683,7 @@ checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "bitflags 2.10.0",
  "bytes",
- "http 1.2.0",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
@@ -4695,9 +4705,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -4718,9 +4728,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,10 +135,10 @@ parking_lot = { version = "0.12", optional = true }
 chrono = {version = "0.4", default-features = false, features = ["serde"]}
 rand = "0.8"
 awc = { version = "3.7.0", features = ["rustls-0_23-native-roots"], optional = true }
-aws-config = { version = "1.1.7", optional = true }
-aws-sdk-bedrockruntime = { version = "1.99.0", optional = true }
-aws-credential-types = { version = "1.2.11", optional = true }
-aws-smithy-types = { version = "1.3.2", optional = true }
+aws-config = { version = "1.7.15", optional = true }
+aws-sdk-bedrockruntime = { version = "1.129.0", optional = true }
+aws-credential-types = { version = "1.2.14", optional = true }
+aws-smithy-types = { version = "1.4.7", optional = true }
 shell-words = { version = "1.1", optional = true }
 portable-pty = { version = "0.8", optional = true }
 pest = { version = "2.7", optional = true }

--- a/examples/bedrock_tool_calling_example.rs
+++ b/examples/bedrock_tool_calling_example.rs
@@ -49,6 +49,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             },
             "required": ["location"]
         }),
+        cache_control: None,
     }];
 
     // Start conversation

--- a/src/backends/aws/mod.rs
+++ b/src/backends/aws/mod.rs
@@ -1502,6 +1502,7 @@ impl ChatProvider for BedrockBackend {
                     name: t.function.name.clone(),
                     description: t.function.description.clone(),
                     input_schema: t.function.parameters.clone(),
+                    cache_control: t.cache_control.clone(),
                 })
                 .collect();
 

--- a/src/backends/aws/mod.rs
+++ b/src/backends/aws/mod.rs
@@ -10,16 +10,16 @@ use async_trait::async_trait;
 use aws_config::BehaviorVersion;
 use aws_sdk_bedrockruntime::{
     types::{
-        CachePointBlock, CachePointType, ContentBlock, ContentBlockDelta, ConversationRole,
-        ConverseStreamOutput, Message, SystemContentBlock, Tool, ToolConfiguration,
-        ToolInputSchema, ToolResultBlock, ToolResultContentBlock, ToolUseBlock,
+        CachePointBlock, CachePointType, ContentBlock, ContentBlockDelta, ContentBlockStart, ConversationRole, ConverseStreamOutput,
+        Message, SystemContentBlock, Tool, ToolConfiguration, ToolInputSchema, ToolResultBlock,
+        ToolResultContentBlock, ToolUseBlock,
     },
     Client as BedrockClient,
 };
 use aws_smithy_types::{Blob, Document};
 use futures::{Stream, StreamExt};
 use serde_json::{json, Value};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::env;
 use std::fs;
 use std::pin::Pin;
@@ -27,7 +27,8 @@ use std::sync::Arc;
 use tokio::sync::OnceCell;
 
 use crate::chat::{
-    ChatMessage as LlmChatMessage, ChatProvider, StructuredOutputFormat, Tool as LlmTool,
+    ChatMessage as LlmChatMessage, ChatProvider, StreamChunk as LlmStreamChunk, StreamChoice,
+    StreamDelta, StreamResponse, StructuredOutputFormat, Tool as LlmTool,
     ToolChoice as LlmToolChoice,
 };
 use crate::completion::{
@@ -38,7 +39,7 @@ use crate::embedding::EmbeddingProvider;
 use crate::models::ModelsProvider;
 use crate::stt::SpeechToTextProvider;
 use crate::tts::TextToSpeechProvider;
-use crate::LLMProvider;
+use crate::{FunctionCall, ToolCall, LLMProvider};
 
 mod error;
 mod models;
@@ -80,6 +81,32 @@ struct PreparedChatRequest {
     system: Option<SystemContentBlock>,
     tool_config: Option<ToolConfiguration>,
     inference_config: aws_sdk_bedrockruntime::types::InferenceConfiguration,
+}
+
+#[derive(Debug, Default, Clone)]
+struct BedrockToolUseState {
+    id: String,
+    name: String,
+    input_buffer: String,
+    started: bool,
+}
+
+impl BedrockToolUseState {
+    fn to_tool_call(&self) -> ToolCall {
+        let arguments = if self.input_buffer.is_empty() {
+            "{}".to_string()
+        } else {
+            self.input_buffer.clone()
+        };
+        ToolCall {
+            id: self.id.clone(),
+            call_type: "function".to_string(),
+            function: FunctionCall {
+                name: self.name.clone(),
+                arguments,
+            },
+        }
+    }
 }
 
 impl BedrockBackend {
@@ -241,6 +268,7 @@ impl BedrockBackend {
                 .set_max_tokens(request.max_tokens.or(self.max_tokens).map(|t| t as i32))
                 .set_temperature(request.temperature.map(|t| t as f32).or(self.temperature))
                 .set_top_p(request.top_p.map(|p| p as f32).or(self.top_p))
+
                 .set_stop_sequences(request.stop_sequences)
                 .build(),
         );
@@ -547,6 +575,150 @@ impl BedrockBackend {
                 }
             }
         }))
+    }
+
+    /// Stream chat responses with tool call events.
+    pub async fn chat_stream_with_tools(
+        &self,
+        request: ChatRequest,
+    ) -> Result<impl futures::Stream<Item = Result<LlmStreamChunk>>> {
+        let client = self.get_client().await?;
+        let PreparedChatRequest {
+            model_id_str,
+            model: _,
+            messages,
+            system,
+            tool_config,
+            inference_config,
+        } = self.prepare_chat_request(request)?;
+
+        let mut converse_request = client
+            .converse_stream()
+            .model_id(model_id_str)
+            .set_messages(Some(messages));
+
+        if let Some(system) = system {
+            converse_request = converse_request.system(system);
+        }
+
+        if let Some(tool_config) = tool_config {
+            converse_request = converse_request.tool_config(tool_config);
+        }
+
+        converse_request = converse_request.inference_config(inference_config);
+
+        let response = converse_request
+            .send()
+            .await
+            .map_err(|e| BedrockError::ApiError(format!("{:?}", e)))?;
+
+        let stream = response.stream;
+
+        let initial_state = (
+            stream,
+            HashMap::<usize, BedrockToolUseState>::new(),
+            VecDeque::<LlmStreamChunk>::new(),
+        );
+
+        Ok(futures::stream::unfold(
+            initial_state,
+            |(mut stream, mut tool_states, mut pending)| async move {
+                loop {
+                    if let Some(chunk) = pending.pop_front() {
+                        return Some((Ok(chunk), (stream, tool_states, pending)));
+                    }
+
+                    let next_item = stream.recv().await;
+                    match next_item {
+                        Ok(Some(event)) => match event {
+                            ConverseStreamOutput::ContentBlockStart(start) => {
+                                if let Some(ContentBlockStart::ToolUse(tool_use)) = start.start {
+                                    let index =
+                                        usize::try_from(start.content_block_index).unwrap_or(0);
+                                    let state = tool_states.entry(index).or_default();
+                                    state.id = tool_use.tool_use_id().to_string();
+                                    state.name = tool_use.name().to_string();
+                                    if !state.started {
+                                        state.started = true;
+                                        pending.push_back(LlmStreamChunk::ToolUseStart {
+                                            index,
+                                            id: state.id.clone(),
+                                            name: state.name.clone(),
+                                        });
+                                    }
+                                }
+                            }
+                            ConverseStreamOutput::ContentBlockDelta(delta) => match delta.delta {
+                                Some(ContentBlockDelta::Text(text)) => {
+                                    if !text.is_empty() {
+                                        pending.push_back(LlmStreamChunk::Text(text));
+                                    }
+                                }
+                                Some(ContentBlockDelta::ToolUse(tool_use)) => {
+                                    let index =
+                                        usize::try_from(delta.content_block_index).unwrap_or(0);
+                                    let state = tool_states.entry(index).or_default();
+                                    if !tool_use.input.is_empty() {
+                                        state.input_buffer.push_str(&tool_use.input);
+                                        pending.push_back(LlmStreamChunk::ToolUseInputDelta {
+                                            index,
+                                            partial_json: tool_use.input,
+                                        });
+                                    }
+                                }
+                                _ => {}
+                            },
+                            ConverseStreamOutput::ContentBlockStop(stop) => {
+                                let index =
+                                    usize::try_from(stop.content_block_index).unwrap_or(0);
+                                if let Some(state) = tool_states.remove(&index) {
+                                    if state.started {
+                                        pending.push_back(LlmStreamChunk::ToolUseComplete {
+                                            index,
+                                            tool_call: state.to_tool_call(),
+                                        });
+                                    }
+                                }
+                            }
+                            ConverseStreamOutput::MessageStop(stop) => {
+                                for (index, state) in tool_states.drain() {
+                                    if state.started {
+                                        pending.push_back(LlmStreamChunk::ToolUseComplete {
+                                            index,
+                                            tool_call: state.to_tool_call(),
+                                        });
+                                    }
+                                }
+                                pending.push_back(LlmStreamChunk::Done {
+                                    stop_reason: stop.stop_reason.as_str().to_string(),
+                                });
+                            }
+                            _ => {}
+                        },
+                        Ok(None) => {
+                            for (index, state) in tool_states.drain() {
+                                if state.started {
+                                    pending.push_back(LlmStreamChunk::ToolUseComplete {
+                                        index,
+                                        tool_call: state.to_tool_call(),
+                                    });
+                                }
+                            }
+                            if let Some(chunk) = pending.pop_front() {
+                                return Some((Ok(chunk), (stream, tool_states, pending)));
+                            }
+                            return None;
+                        }
+                        Err(e) => {
+                            return Some((
+                                Err(BedrockError::StreamError(format!("{:?}", e))),
+                                (stream, tool_states, pending),
+                            ))
+                        }
+                    }
+                }
+            },
+        ))
     }
 
     // Helper methods
@@ -1207,6 +1379,146 @@ impl ChatProvider for BedrockBackend {
 
         Ok(Box::pin(stream))
     }
+
+    async fn chat_stream_struct(
+        &self,
+        messages: &[LlmChatMessage],
+    ) -> std::result::Result<
+        Pin<Box<dyn Stream<Item = std::result::Result<StreamResponse, crate::error::LLMError>> + Send>>,
+        crate::error::LLMError,
+    > {
+        let aws_messages: Vec<ChatMessage> = messages
+            .iter()
+            .map(|m| {
+                let role = match m.role {
+                    crate::chat::ChatRole::User => "user",
+                    crate::chat::ChatRole::Assistant => "assistant",
+                };
+
+                let content = match &m.message_type {
+                    crate::chat::MessageType::Text => MessageContent::Text(m.content.clone()),
+                    crate::chat::MessageType::Image((mime, bytes)) => {
+                        MessageContent::MultiModal(vec![
+                            ContentPart::Text {
+                                text: m.content.clone(),
+                            },
+                            ContentPart::Image {
+                                source: bytes.clone(),
+                                media_type: mime.mime_type().to_string(),
+                            },
+                        ])
+                    }
+                    _ => MessageContent::Text(m.content.clone()),
+                };
+
+                ChatMessage {
+                    role: role.to_string(),
+                    content,
+                }
+            })
+            .collect();
+
+        let request = ChatRequest::new(aws_messages);
+        let stream = BedrockBackend::chat_stream_with_tools(self, request)
+            .await
+            .map_err(|e| crate::error::LLMError::ProviderError(e.to_string()))?;
+
+        let stream = stream.filter_map(|item| async move {
+            match item {
+                Ok(LlmStreamChunk::Text(text)) => Some(Ok(StreamResponse {
+                    choices: vec![StreamChoice {
+                        delta: StreamDelta {
+                            content: Some(text),
+                            tool_calls: None,
+                        },
+                    }],
+                    usage: None,
+                })),
+                Ok(LlmStreamChunk::ToolUseComplete { tool_call, .. }) => {
+                    Some(Ok(StreamResponse {
+                        choices: vec![StreamChoice {
+                            delta: StreamDelta {
+                                content: None,
+                                tool_calls: Some(vec![tool_call]),
+                            },
+                        }],
+                        usage: None,
+                    }))
+                }
+                Ok(LlmStreamChunk::Done { .. }) => None,
+                Ok(_) => None,
+                Err(e) => Some(Err(crate::error::LLMError::ProviderError(e.to_string()))),
+            }
+        });
+
+        Ok(Box::pin(stream))
+    }
+
+    async fn chat_stream_with_tools(
+        &self,
+        messages: &[LlmChatMessage],
+        tools: Option<&[LlmTool]>,
+    ) -> std::result::Result<
+        Pin<Box<dyn Stream<Item = std::result::Result<LlmStreamChunk, crate::error::LLMError>> + Send>>,
+        crate::error::LLMError,
+    > {
+        let aws_messages: Vec<ChatMessage> = messages
+            .iter()
+            .map(|m| {
+                let role = match m.role {
+                    crate::chat::ChatRole::User => "user",
+                    crate::chat::ChatRole::Assistant => "assistant",
+                };
+
+                let content = match &m.message_type {
+                    crate::chat::MessageType::Text => MessageContent::Text(m.content.clone()),
+                    crate::chat::MessageType::Image((mime, bytes)) => {
+                        MessageContent::MultiModal(vec![
+                            ContentPart::Text {
+                                text: m.content.clone(),
+                            },
+                            ContentPart::Image {
+                                source: bytes.clone(),
+                                media_type: mime.mime_type().to_string(),
+                            },
+                        ])
+                    }
+                    _ => MessageContent::Text(m.content.clone()),
+                };
+
+                ChatMessage {
+                    role: role.to_string(),
+                    content,
+                }
+            })
+            .collect();
+
+        let mut request = ChatRequest::new(aws_messages);
+
+        if let Some(tools) = tools {
+            let tool_defs: Vec<ToolDefinition> = tools
+                .iter()
+                .map(|t| ToolDefinition {
+                    name: t.function.name.clone(),
+                    description: t.function.description.clone(),
+                    input_schema: t.function.parameters.clone(),
+                })
+                .collect();
+
+            request = request.with_tools(tool_defs);
+        }
+
+        let stream = BedrockBackend::chat_stream_with_tools(self, request)
+            .await
+            .map_err(|e| crate::error::LLMError::ProviderError(e.to_string()))?;
+
+        let stream = stream.map(|item| match item {
+            Ok(chunk) => Ok(chunk),
+            Err(e) => Err(crate::error::LLMError::ProviderError(e.to_string())),
+        });
+
+        Ok(Box::pin(stream))
+    }
 }
 
 #[async_trait]
@@ -1414,5 +1726,18 @@ streaming = true
         assert_eq!(tools.len(), 2);
         assert!(matches!(tools[0], Tool::ToolSpec(_)));
         assert!(matches!(tools[1], Tool::CachePoint(_)));
+    }
+
+    #[test]
+    fn test_tool_use_state_defaults_empty_arguments() {
+        let state = BedrockToolUseState {
+            id: "tooluse_1".to_string(),
+            name: "get_servers".to_string(),
+            ..Default::default()
+        };
+
+        let tool_call = state.to_tool_call();
+
+        assert_eq!(tool_call.function.arguments, "{}");
     }
 }

--- a/src/backends/azure_openai.rs
+++ b/src/backends/azure_openai.rs
@@ -32,7 +32,7 @@ pub struct AzureOpenAIConfig {
     /// API key for authentication.
     pub api_key: String,
     /// API version string.
-    pub api_version: String,
+    pub api_version: Option<String>,
     /// Base URL for API requests.
     pub base_url: Url,
     /// Model identifier.
@@ -363,7 +363,7 @@ impl AzureOpenAI {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         api_key: impl Into<String>,
-        api_version: impl Into<String>,
+        api_version: Option<String>,
         deployment_id: impl Into<String>,
         endpoint: impl Into<String>,
         model: Option<String>,
@@ -411,7 +411,7 @@ impl AzureOpenAI {
     pub fn with_client(
         client: Client,
         api_key: impl Into<String>,
-        api_version: impl Into<String>,
+        api_version: Option<String>,
         deployment_id: impl Into<String>,
         endpoint: impl Into<String>,
         model: Option<String>,
@@ -429,13 +429,13 @@ impl AzureOpenAI {
         json_schema: Option<StructuredOutputFormat>,
     ) -> Self {
         let endpoint = endpoint.into();
-        let deployment_id = deployment_id.into();
+        let _deployment_id = deployment_id.into();
 
         Self {
             config: Arc::new(AzureOpenAIConfig {
                 api_key: api_key.into(),
-                api_version: api_version.into(),
-                base_url: Url::parse(&format!("{endpoint}/openai/deployments/{deployment_id}/"))
+                api_version,
+                base_url: Url::parse(&format!("{endpoint}/openai/v1/"))
                     .expect("Failed to parse base Url"),
                 model: model.unwrap_or("gpt-3.5-turbo".to_string()),
                 max_tokens,
@@ -459,7 +459,7 @@ impl AzureOpenAI {
         &self.config.api_key
     }
 
-    pub fn api_version(&self) -> &str {
+    pub fn api_version(&self) -> &Option<String> {
         &self.config.api_version
     }
 
@@ -626,9 +626,12 @@ impl ChatProvider for AzureOpenAI {
             .join("chat/completions")
             .map_err(|e| LLMError::HttpError(e.to_string()))?;
 
-        url.query_pairs_mut()
-            .append_pair("api-version", &self.config.api_version);
+            if let Some(api_version) = &self.config.api_version {
+                url.query_pairs_mut()
+                    .append_pair("api-version", api_version);
+            }
 
+        log::info!("Azure OpenAI HTTP Request {}", url);
         let mut request = self
             .client
             .post(url)
@@ -649,7 +652,7 @@ impl ChatProvider for AzureOpenAI {
             let status = response.status();
             let error_text = response.text().await?;
             return Err(LLMError::ResponseFormatError {
-                message: format!("OpenAI API returned error status: {status}"),
+                message: format!("Azure OpenAI API returned error status: {status}"),
                 raw_response: error_text,
             });
         }
@@ -712,8 +715,10 @@ impl EmbeddingProvider for AzureOpenAI {
             .join("embeddings")
             .map_err(|e| LLMError::HttpError(e.to_string()))?;
 
-        url.query_pairs_mut()
-            .append_pair("api-version", &self.config.api_version);
+            if let Some(api_version) = &self.config.api_version {
+                url.query_pairs_mut()
+                    .append_pair("api-version", api_version);
+            }
 
         let resp = self
             .client
@@ -773,8 +778,10 @@ impl ModelsProvider for AzureOpenAI {
             .join("models")
             .map_err(|e| LLMError::HttpError(e.to_string()))?;
 
-        url.query_pairs_mut()
-            .append_pair("api-version", &self.config.api_version);
+            if let Some(api_version) = &self.config.api_version {
+                url.query_pairs_mut()
+                    .append_pair("api-version", api_version);
+            }
 
         let mut request = self.client.get(url).header("api-key", &self.config.api_key);
 

--- a/src/backends/azure_openai.rs
+++ b/src/backends/azure_openai.rs
@@ -390,7 +390,7 @@ impl AzureOpenAI {
     /// # Arguments
     ///
     /// * `api_key` - OpenAI API key
-    /// * `model` - Model to use (defaults to "gpt-3.5-turbo")
+    /// * `model` - Model to use (defaults to the deployment ID)
     /// * `max_tokens` - Maximum tokens to generate
     /// * `temperature` - Sampling temperature
     /// * `timeout_seconds` - Request timeout in seconds
@@ -473,7 +473,7 @@ impl AzureOpenAI {
         json_schema: Option<StructuredOutputFormat>,
     ) -> Self {
         let endpoint = endpoint.into();
-        let _deployment_id = deployment_id.into();
+        let deployment_id = deployment_id.into();
 
         Self {
             config: Arc::new(AzureOpenAIConfig {
@@ -481,7 +481,7 @@ impl AzureOpenAI {
                 api_version,
                 base_url: Url::parse(&format!("{endpoint}/openai/v1/"))
                     .expect("Failed to parse base Url"),
-                model: model.unwrap_or("gpt-3.5-turbo".to_string()),
+                model: model.unwrap_or(deployment_id),
                 max_tokens,
                 temperature,
                 system,
@@ -1239,6 +1239,7 @@ impl ModelsProvider for AzureOpenAI {
 #[cfg(all(test, feature = "azure_openai"))]
 mod tests {
     use super::*;
+    use reqwest::Client;
 
     #[test]
     fn parse_azure_stream_tool_only_deltas() {
@@ -1275,5 +1276,31 @@ mod tests {
             &chunks[1],
             StreamChunk::Done { stop_reason } if stop_reason == "tool_use"
         ));
+    }
+
+    #[test]
+    fn falls_back_to_deployment_id_when_model_is_unset() {
+        let client = AzureOpenAI::with_client(
+            Client::new(),
+            "test-key",
+            Some("2024-10-21".to_string()),
+            "my-deployment",
+            "https://example.openai.azure.com",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+
+        assert_eq!(client.config.model, "my-deployment");
     }
 }

--- a/src/backends/azure_openai.rs
+++ b/src/backends/azure_openai.rs
@@ -8,7 +8,10 @@ use std::sync::Arc;
 use crate::{
     builder::LLMBackend,
     chat::Tool,
-    chat::{ChatMessage, ChatProvider, ChatRole, MessageType, StructuredOutputFormat},
+    chat::{
+        ChatMessage, ChatProvider, ChatRole, MessageType, StreamChunk, StreamResponse,
+        StructuredOutputFormat,
+    },
     completion::{CompletionProvider, CompletionRequest, CompletionResponse},
     embedding::EmbeddingProvider,
     error::LLMError,
@@ -17,6 +20,8 @@ use crate::{
     tts::TextToSpeechProvider,
     LLMProvider,
 };
+#[cfg(feature = "azure_openai")]
+use futures::StreamExt;
 use crate::{
     chat::{ChatResponse, ToolChoice},
     FunctionCall, ToolCall,
@@ -673,6 +678,274 @@ impl ChatProvider for AzureOpenAI {
 
     async fn chat(&self, messages: &[ChatMessage]) -> Result<Box<dyn ChatResponse>, LLMError> {
         self.chat_with_tools(messages, None).await
+    }
+
+    async fn chat_stream(
+        &self,
+        messages: &[ChatMessage],
+    ) -> Result<
+        std::pin::Pin<Box<dyn futures::Stream<Item = Result<String, LLMError>> + Send>>,
+        LLMError,
+    > {
+        let struct_stream = self.chat_stream_struct(messages).await?;
+        let content_stream = struct_stream.filter_map(|result| async move {
+            match result {
+                Ok(stream_response) => {
+                    if let Some(choice) = stream_response.choices.first() {
+                        if let Some(content) = &choice.delta.content {
+                            if !content.is_empty() {
+                                return Some(Ok(content.clone()));
+                            }
+                        }
+                    }
+                    None
+                }
+                Err(e) => Some(Err(e)),
+            }
+        });
+        Ok(Box::pin(content_stream))
+    }
+
+    async fn chat_stream_struct(
+        &self,
+        messages: &[ChatMessage],
+    ) -> Result<
+        std::pin::Pin<Box<dyn futures::Stream<Item = Result<StreamResponse, LLMError>> + Send>>,
+        LLMError,
+    > {
+        use crate::providers::openai_compatible::create_sse_stream;
+
+        crate::chat::ensure_no_audio(messages, AUDIO_UNSUPPORTED)?;
+        if self.config.api_key.is_empty() {
+            return Err(LLMError::AuthError(
+                "Missing Azure OpenAI API key".to_string(),
+            ));
+        }
+
+        let mut openai_msgs: Vec<AzureOpenAIChatMessage> = vec![];
+
+        for msg in messages {
+            if let MessageType::ToolResult(ref results) = msg.message_type {
+                for result in results {
+                    openai_msgs.push(AzureOpenAIChatMessage {
+                        role: "tool",
+                        tool_call_id: Some(result.id.clone()),
+                        tool_calls: None,
+                        content: Some(either::Right(result.function.arguments.clone())),
+                    });
+                }
+            } else {
+                openai_msgs.push(msg.into())
+            }
+        }
+
+        if let Some(system) = &self.config.system {
+            openai_msgs.insert(
+                0,
+                AzureOpenAIChatMessage {
+                    role: "system",
+                    content: Some(either::Left(vec![AzureMessageContent {
+                        message_type: Some("text"),
+                        text: Some(system),
+                        image_url: None,
+                        tool_call_id: None,
+                        tool_output: None,
+                    }])),
+                    tool_calls: None,
+                    tool_call_id: None,
+                },
+            );
+        }
+
+        let response_format: Option<OpenAIResponseFormat> =
+            self.config.json_schema.clone().map(|s| s.into());
+
+        let request_tools = self.config.tools.clone();
+        let request_tool_choice = if request_tools.is_some() {
+            self.config.tool_choice.clone()
+        } else {
+            None
+        };
+
+        let body = AzureOpenAIChatRequest {
+            model: &self.config.model,
+            messages: openai_msgs,
+            max_tokens: self.config.max_tokens,
+            temperature: self.config.temperature,
+            stream: true,
+            top_p: self.config.top_p,
+            top_k: self.config.top_k,
+            tools: request_tools,
+            tool_choice: request_tool_choice,
+            reasoning_effort: self.config.reasoning_effort.clone(),
+            response_format,
+        };
+
+        if log::log_enabled!(log::Level::Trace) {
+            if let Ok(json) = serde_json::to_string(&body) {
+                log::trace!("Azure OpenAI stream request payload: {}", json);
+            }
+        }
+
+        let mut url = self
+            .config
+            .base_url
+            .join("chat/completions")
+            .map_err(|e| LLMError::HttpError(e.to_string()))?;
+
+        if let Some(api_version) = &self.config.api_version {
+            url.query_pairs_mut()
+                .append_pair("api-version", api_version);
+        }
+
+        log::info!("Azure OpenAI stream HTTP Request {}", url);
+        let mut request = self
+            .client
+            .post(url)
+            .header("api-key", &self.config.api_key)
+            .json(&body);
+
+        if let Some(timeout) = self.config.timeout_seconds {
+            request = request.timeout(std::time::Duration::from_secs(timeout));
+        }
+
+        let response = request.send().await?;
+        log::debug!("Azure OpenAI stream HTTP status: {}", response.status());
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await?;
+            return Err(LLMError::ResponseFormatError {
+                message: format!("Azure OpenAI API returned error status: {status}"),
+                raw_response: error_text,
+            });
+        }
+
+        Ok(create_sse_stream(response, false))
+    }
+
+    async fn chat_stream_with_tools(
+        &self,
+        messages: &[ChatMessage],
+        tools: Option<&[Tool]>,
+    ) -> Result<
+        std::pin::Pin<Box<dyn futures::Stream<Item = Result<StreamChunk, LLMError>> + Send>>,
+        LLMError,
+    > {
+        use crate::providers::openai_compatible::create_sse_stream;
+
+        crate::chat::ensure_no_audio(messages, AUDIO_UNSUPPORTED)?;
+        if self.config.api_key.is_empty() {
+            return Err(LLMError::AuthError(
+                "Missing Azure OpenAI API key".to_string(),
+            ));
+        }
+
+        let mut openai_msgs: Vec<AzureOpenAIChatMessage> = vec![];
+
+        for msg in messages {
+            if let MessageType::ToolResult(ref results) = msg.message_type {
+                for result in results {
+                    openai_msgs.push(AzureOpenAIChatMessage {
+                        role: "tool",
+                        tool_call_id: Some(result.id.clone()),
+                        tool_calls: None,
+                        content: Some(either::Right(result.function.arguments.clone())),
+                    });
+                }
+            } else {
+                openai_msgs.push(msg.into())
+            }
+        }
+
+        if let Some(system) = &self.config.system {
+            openai_msgs.insert(
+                0,
+                AzureOpenAIChatMessage {
+                    role: "system",
+                    content: Some(either::Left(vec![AzureMessageContent {
+                        message_type: Some("text"),
+                        text: Some(system),
+                        image_url: None,
+                        tool_call_id: None,
+                        tool_output: None,
+                    }])),
+                    tool_calls: None,
+                    tool_call_id: None,
+                },
+            );
+        }
+
+        let response_format: Option<OpenAIResponseFormat> =
+            self.config.json_schema.clone().map(|s| s.into());
+
+        let effective_tools = tools
+            .map(|t| t.to_vec())
+            .or_else(|| self.config.tools.clone());
+        let request_tool_choice = if effective_tools.is_some() {
+            self.config.tool_choice.clone()
+        } else {
+            None
+        };
+
+        let body = AzureOpenAIChatRequest {
+            model: &self.config.model,
+            messages: openai_msgs,
+            max_tokens: self.config.max_tokens,
+            temperature: self.config.temperature,
+            stream: true,
+            top_p: self.config.top_p,
+            top_k: self.config.top_k,
+            tools: effective_tools,
+            tool_choice: request_tool_choice,
+            reasoning_effort: self.config.reasoning_effort.clone(),
+            response_format,
+        };
+
+        let mut url = self
+            .config
+            .base_url
+            .join("chat/completions")
+            .map_err(|e| LLMError::HttpError(e.to_string()))?;
+
+        if let Some(api_version) = &self.config.api_version {
+            url.query_pairs_mut()
+                .append_pair("api-version", api_version);
+        }
+
+        let mut request = self
+            .client
+            .post(url)
+            .header("api-key", &self.config.api_key)
+            .json(&body);
+
+        if let Some(timeout) = self.config.timeout_seconds {
+            request = request.timeout(std::time::Duration::from_secs(timeout));
+        }
+
+        let response = request.send().await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await?;
+            return Err(LLMError::ResponseFormatError {
+                message: format!("Azure OpenAI API returned error status: {status}"),
+                raw_response: error_text,
+            });
+        }
+
+        let struct_stream = create_sse_stream(response, false);
+        let chunk_stream = struct_stream.map(|result| {
+            result.map(|sr| {
+                let text = sr
+                    .choices
+                    .first()
+                    .and_then(|c| c.delta.content.clone())
+                    .unwrap_or_default();
+                StreamChunk::Text(text)
+            })
+        });
+        Ok(Box::pin(chunk_stream))
     }
 }
 

--- a/src/backends/azure_openai.rs
+++ b/src/backends/azure_openai.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides integration with Azure OpenAI's GPT models through their API.
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 #[cfg(feature = "azure_openai")]
 use crate::{
@@ -21,7 +21,7 @@ use crate::{
     LLMProvider,
 };
 #[cfg(feature = "azure_openai")]
-use futures::StreamExt;
+use futures::{Stream, StreamExt};
 use crate::{
     chat::{ChatResponse, ToolChoice},
     FunctionCall, ToolCall,
@@ -252,6 +252,45 @@ struct AzureOpenAIEmbeddingData {
 #[derive(Deserialize, Debug)]
 struct OpenAIEmbeddingResponse {
     data: Vec<AzureOpenAIEmbeddingData>,
+}
+
+#[derive(Debug, Default)]
+struct AzureToolUseState {
+    id: String,
+    name: String,
+    arguments_buffer: String,
+    started: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct AzureToolStreamChunk {
+    choices: Vec<AzureToolStreamChoice>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AzureToolStreamChoice {
+    delta: AzureToolStreamDelta,
+    finish_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AzureToolStreamDelta {
+    content: Option<String>,
+    tool_calls: Option<Vec<AzureToolStreamToolCall>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AzureToolStreamToolCall {
+    index: Option<usize>,
+    id: Option<String>,
+    function: AzureToolStreamFunction,
+}
+
+#[derive(Debug, Deserialize)]
+struct AzureToolStreamFunction {
+    name: Option<String>,
+    #[serde(default)]
+    arguments: String,
 }
 
 /// An object specifying the format that the model must output.
@@ -527,6 +566,145 @@ impl AzureOpenAI {
     pub fn client(&self) -> &Client {
         &self.client
     }
+}
+
+#[cfg(feature = "azure_openai")]
+fn parse_azure_sse_chunk_with_tools(
+    event: &str,
+    tool_states: &mut HashMap<usize, AzureToolUseState>,
+) -> Result<Vec<StreamChunk>, LLMError> {
+    let mut results = Vec::new();
+
+    for line in event.lines() {
+        let line = line.trim();
+        let Some(data) = line.strip_prefix("data: ") else {
+            continue;
+        };
+
+        if data == "[DONE]" {
+            finish_azure_tool_calls(&mut results, tool_states);
+            results.push(StreamChunk::Done {
+                stop_reason: "end_turn".to_string(),
+            });
+            return Ok(results);
+        }
+
+        if let Ok(chunk) = serde_json::from_str::<AzureToolStreamChunk>(data) {
+            for choice in &chunk.choices {
+                if let Some(content) = &choice.delta.content {
+                    if !content.is_empty() {
+                        results.push(StreamChunk::Text(content.clone()));
+                    }
+                }
+
+                if let Some(tool_calls) = &choice.delta.tool_calls {
+                    for tc in tool_calls {
+                        let index = tc.index.unwrap_or(0);
+                        let state = tool_states.entry(index).or_default();
+
+                        if let Some(id) = &tc.id {
+                            state.id = id.clone();
+                        }
+                        if let Some(name) = &tc.function.name {
+                            state.name = name.clone();
+                            if !state.started {
+                                state.started = true;
+                                results.push(StreamChunk::ToolUseStart {
+                                    index,
+                                    id: state.id.clone(),
+                                    name: state.name.clone(),
+                                });
+                            }
+                        }
+
+                        if !tc.function.arguments.is_empty() {
+                            state.arguments_buffer.push_str(&tc.function.arguments);
+                            results.push(StreamChunk::ToolUseInputDelta {
+                                index,
+                                partial_json: tc.function.arguments.clone(),
+                            });
+                        }
+                    }
+                }
+
+                if let Some(finish_reason) = &choice.finish_reason {
+                    finish_azure_tool_calls(&mut results, tool_states);
+                    let stop_reason = match finish_reason.as_str() {
+                        "tool_calls" => "tool_use",
+                        "stop" => "end_turn",
+                        other => other,
+                    };
+                    results.push(StreamChunk::Done {
+                        stop_reason: stop_reason.to_string(),
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(results)
+}
+
+#[cfg(feature = "azure_openai")]
+fn finish_azure_tool_calls(
+    results: &mut Vec<StreamChunk>,
+    tool_states: &mut HashMap<usize, AzureToolUseState>,
+) {
+    for (index, state) in tool_states.drain() {
+        if state.started {
+            results.push(StreamChunk::ToolUseComplete {
+                index,
+                tool_call: ToolCall {
+                    id: state.id,
+                    call_type: "function".to_string(),
+                    function: FunctionCall {
+                        name: state.name,
+                        arguments: state.arguments_buffer,
+                    },
+                },
+            });
+        }
+    }
+}
+
+#[cfg(feature = "azure_openai")]
+fn create_azure_sse_stream_with_tools(
+    response: reqwest::Response,
+) -> std::pin::Pin<Box<dyn Stream<Item = Result<StreamChunk, LLMError>> + Send>> {
+    let bytes_stream = response.bytes_stream();
+    let stream = bytes_stream
+        .scan(
+            (String::new(), HashMap::<usize, AzureToolUseState>::new()),
+            |(event_buffer, tool_states), chunk| {
+                let results = match chunk {
+                    Ok(bytes) => {
+                        let text = String::from_utf8_lossy(&bytes);
+                        let mut results = Vec::new();
+                        for line in text.lines() {
+                            let line = line.trim_end();
+                            if line.is_empty() {
+                                if !event_buffer.is_empty() {
+                                    match parse_azure_sse_chunk_with_tools(event_buffer, tool_states)
+                                    {
+                                        Ok(chunks) => results.extend(chunks.into_iter().map(Ok)),
+                                        Err(e) => results.push(Err(e)),
+                                    }
+                                    event_buffer.clear();
+                                }
+                            } else {
+                                event_buffer.push_str(line);
+                                event_buffer.push('\n');
+                            }
+                        }
+                        results
+                    }
+                    Err(e) => vec![Err(LLMError::HttpError(e.to_string()))],
+                };
+                futures::future::ready(Some(results))
+            },
+        )
+        .flat_map(futures::stream::iter);
+    Box::pin(stream)
 }
 
 const AUDIO_UNSUPPORTED: &str = "Audio messages are not supported by Azure OpenAI chat";
@@ -832,8 +1010,6 @@ impl ChatProvider for AzureOpenAI {
         std::pin::Pin<Box<dyn futures::Stream<Item = Result<StreamChunk, LLMError>> + Send>>,
         LLMError,
     > {
-        use crate::providers::openai_compatible::create_sse_stream;
-
         crate::chat::ensure_no_audio(messages, AUDIO_UNSUPPORTED)?;
         if self.config.api_key.is_empty() {
             return Err(LLMError::AuthError(
@@ -934,18 +1110,7 @@ impl ChatProvider for AzureOpenAI {
             });
         }
 
-        let struct_stream = create_sse_stream(response, false);
-        let chunk_stream = struct_stream.map(|result| {
-            result.map(|sr| {
-                let text = sr
-                    .choices
-                    .first()
-                    .and_then(|c| c.delta.content.clone())
-                    .unwrap_or_default();
-                StreamChunk::Text(text)
-            })
-        });
-        Ok(Box::pin(chunk_stream))
+        Ok(create_azure_sse_stream_with_tools(response))
     }
 }
 
@@ -1068,5 +1233,47 @@ impl ModelsProvider for AzureOpenAI {
             backend: LLMBackend::AzureOpenAI,
         };
         Ok(Box::new(result))
+    }
+}
+
+#[cfg(all(test, feature = "azure_openai"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_azure_stream_tool_only_deltas() {
+        let mut tool_states = HashMap::new();
+
+        let start = r#"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_abc123","type":"function","function":{"name":"get_weather","arguments":""}}]},"finish_reason":null}]}"#;
+        let chunks = parse_azure_sse_chunk_with_tools(start, &mut tool_states).unwrap();
+        assert!(matches!(
+            &chunks[0],
+            StreamChunk::ToolUseStart { index: 0, id, name }
+            if id == "call_abc123" && name == "get_weather"
+        ));
+
+        let delta = r#"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"city\":\"Paris\"}"}}]},"finish_reason":null}]}"#;
+        let chunks = parse_azure_sse_chunk_with_tools(delta, &mut tool_states).unwrap();
+        assert!(matches!(
+            &chunks[0],
+            StreamChunk::ToolUseInputDelta { index: 0, partial_json }
+            if partial_json == "{\"city\":\"Paris\"}"
+        ));
+
+        let finish =
+            r#"data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}"#;
+        let chunks = parse_azure_sse_chunk_with_tools(finish, &mut tool_states).unwrap();
+        assert_eq!(chunks.len(), 2);
+        assert!(matches!(
+            &chunks[0],
+            StreamChunk::ToolUseComplete { index: 0, tool_call }
+            if tool_call.id == "call_abc123"
+                && tool_call.function.name == "get_weather"
+                && tool_call.function.arguments == "{\"city\":\"Paris\"}"
+        ));
+        assert!(matches!(
+            &chunks[1],
+            StreamChunk::Done { stop_reason } if stop_reason == "tool_use"
+        ));
     }
 }

--- a/src/backends/azure_openai.rs
+++ b/src/backends/azure_openai.rs
@@ -205,7 +205,7 @@ struct OpenAIEmbeddingRequest {
 struct AzureOpenAIChatRequest<'a> {
     model: &'a str,
     messages: Vec<AzureOpenAIChatMessage<'a>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "max_completion_tokens", skip_serializing_if = "Option::is_none")]
     max_tokens: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f32>,

--- a/src/backends/openai/responses/request/tests.rs
+++ b/src/backends/openai/responses/request/tests.rs
@@ -38,6 +38,7 @@ fn sample_tool() -> Tool {
             description: "Get weather".to_string(),
             parameters: json!({"type": "object"}),
         },
+        cache_control: None,
     }
 }
 

--- a/src/builder/build/backends/azure.rs
+++ b/src/builder/build/backends/azure.rs
@@ -27,7 +27,7 @@ pub(super) fn build_azure_openai(
     let timeout = helpers::timeout_or_default(state);
     let provider = crate::backends::azure_openai::AzureOpenAI::new(
         api_key,
-        api_version,
+        Option::from(api_version),
         deployment,
         endpoint,
         state.model.take(),

--- a/src/builder/build/backends/azure.rs
+++ b/src/builder/build/backends/azure.rs
@@ -17,9 +17,6 @@ pub(super) fn build_azure_openai(
         LLMError::InvalidRequest("No API endpoint provided for Azure OpenAI".into())
     })?;
     let api_key = helpers::require_api_key(state, "Azure OpenAI")?;
-    let api_version = state.api_version.take().ok_or_else(|| {
-        LLMError::InvalidRequest("No API version provided for Azure OpenAI".to_string())
-    })?;
     let deployment = state.deployment_id.take().ok_or_else(|| {
         LLMError::InvalidRequest("No deployment ID provided for Azure OpenAI".into())
     })?;
@@ -27,7 +24,7 @@ pub(super) fn build_azure_openai(
     let timeout = helpers::timeout_or_default(state);
     let provider = crate::backends::azure_openai::AzureOpenAI::new(
         api_key,
-        Option::from(api_version),
+        state.api_version.clone(),
         deployment,
         endpoint,
         state.model.take(),

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -8,7 +8,7 @@ mod bedrock_tests {
     use aws_config::{load_defaults, BehaviorVersion};
     use aws_credential_types::provider::ProvideCredentials;
     use llm::backends::aws::*;
-    use llm::chat::StructuredOutputFormat;
+    use llm::chat::{StreamChunk, StructuredOutputFormat};
     use serde_json::json;
 
     // Helper to check if AWS credentials are available
@@ -306,6 +306,71 @@ mod bedrock_tests {
             }
             _ => panic!("Expected multimodal content with tool use"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_streaming_chat_with_tools() {
+        if skip_if_no_credentials().await {
+            println!("Skipping test: no AWS credentials");
+            return;
+        }
+
+        let backend = BedrockBackend::from_env().await.unwrap();
+
+        let tools = vec![ToolDefinition {
+            name: "get_weather".to_string(),
+            description: "Get the current weather for a location".to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "location": {
+                        "type": "string",
+                        "description": "The city and state, e.g. San Francisco, CA"
+                    }
+                },
+                "required": ["location"]
+            }),
+        }];
+
+        let messages = vec![ChatMessage::user(
+            "What's the weather in San Francisco? Use get_weather to answer.",
+        )];
+
+        let request = ChatRequest::new(messages)
+            .with_model(BedrockModel::eu(CrossRegionModel::ClaudeSonnet4))
+            .with_tools(tools)
+            .with_max_tokens(500);
+
+        let stream = backend.chat_stream_with_tools(request).await;
+        assert!(
+            stream.is_ok(),
+            "Streaming tool use chat failed: {:?}",
+            stream.err()
+        );
+
+        use futures::StreamExt;
+        let stream = stream.unwrap();
+        futures::pin_mut!(stream);
+        let mut saw_tool_call = false;
+
+        while let Some(chunk_result) = stream.next().await {
+            assert!(chunk_result.is_ok());
+            match chunk_result.unwrap() {
+                StreamChunk::ToolUseComplete { tool_call, .. } => {
+                    if tool_call.function.name == "get_weather" {
+                        saw_tool_call = true;
+                    }
+                }
+                StreamChunk::ToolUseStart { name, .. } => {
+                    if name == "get_weather" {
+                        saw_tool_call = true;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        assert!(saw_tool_call, "Expected streaming tool use for get_weather");
     }
 
     #[tokio::test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -278,6 +278,7 @@ mod bedrock_tests {
                 },
                 "required": ["location"]
             }),
+            cache_control: None,
         }];
 
         let messages = vec![ChatMessage::user("What's the weather in San Francisco?")];
@@ -330,6 +331,7 @@ mod bedrock_tests {
                 },
                 "required": ["location"]
             }),
+            cache_control: None,
         }];
 
         let messages = vec![ChatMessage::user(
@@ -395,6 +397,7 @@ mod bedrock_tests {
                 },
                 "required": ["expression"]
             }),
+            cache_control: None,
         }];
 
         // First request to get tool use
@@ -729,6 +732,7 @@ mod bedrock_tests {
             name: "test_tool".to_string(),
             description: "A test tool".to_string(),
             input_schema: json!({"type": "object"}),
+            cache_control: None,
         }];
 
         let messages = vec![ChatMessage::user("Use the tool")];


### PR DESCRIPTION
tl;dr 
- We were trying to use this library on an Azure OpenAI Deployment, and had to change multiple things to make it work.
- AWS Streaming for tool calls
- Dependency updates


**AWS Bedrock Backend Enhancements:**

* Streaming tool call support:
  - Implements a new `chat_stream_with_tools` method in `BedrockBackend` to stream chat responses, including tool call events, and introduces the `BedrockToolUseState` struct to manage tool call state during streaming.
* Dependency updates:
  - Bumps several AWS SDK dependencies to more recent versions for improved compatibility and bug fixes in `Cargo.toml`.

**Azure OpenAI Backend Adjustments:**

* API version handling and endpoint changes:
  - Changes `api_version` from a required string to an optional field, and updates construction logic to use the new OpenAI v1 endpoint format.

Note that the Azure OpenAI API changes are quite huge, that would be a breaking change I'd assume. Not sure when it changed, and/or if this has been rolled out over all regions