### PR TITLE
docs: update README dependency example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Simply add **LLM** to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-llm = { version = "1.2.4", features = ["openai", "anthropic", "ollama", "deepseek", "xai", "phind", "google", "groq", "mistral", "Elevenlabs"] }
+llm = { version = "1.3.8", features = ["openai", "anthropic", "ollama", "deepseek", "xai", "phind", "google", "groq", "mistral", "elevenlabs"] }
 ```
 
 ## Use any LLM on cli
@@ -57,7 +57,7 @@ LLM includes a command-line tool for easily interacting with different LLM model
 
 ```shell
 [dependencies]
-llm = { version = "1.2.4", features = ["openai", "anthropic", "ollama", "deepseek", "xai", "phind", "google", "groq", "api", "mistral", "elevenlabs"] }
+llm = { version = "1.3.8", features = ["openai", "anthropic", "ollama", "deepseek", "xai", "phind", "google", "groq", "api", "mistral", "elevenlabs"] }
 ```
 
 More details in the [`api_example`](examples/api_example.rs)


### PR DESCRIPTION
## Summary
- update the README Cargo.toml snippets to the current crate version (1.3.8)
- use the lowercase `elevenlabs` feature name to match Cargo.toml

## Validation
- Checked README snippets against Cargo.toml version/features
- `git diff --check`