### PR TITLE
Omit temperature/top_p/top_k for Claude 5-gen models on Anthropic backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2977,15 +2977,14 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "openssl"
-version = "0.10.68"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -3015,9 +3014,9 @@ checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ full = [
     "openrouter",
     "huggingface",
     "bedrock",
+    "vertex_ai",
 ]
 openai = []
 anthropic = []
@@ -56,6 +57,7 @@ bedrock = [
     "dep:aws-sdk-bedrockruntime",
     "dep:aws-smithy-types",
 ]
+vertex_ai = []
 cli = [
     "full",
     "dep:anyhow",

--- a/src/backends/anthropic.rs
+++ b/src/backends/anthropic.rs
@@ -953,7 +953,7 @@ impl ChatProvider for Anthropic {
 }
 
 /// Creates an SSE stream that parses Anthropic tool use events into StreamChunk.
-fn create_anthropic_tool_stream(
+pub(crate) fn create_anthropic_tool_stream(
     response: reqwest::Response,
 ) -> std::pin::Pin<Box<dyn Stream<Item = Result<StreamChunk, LLMError>> + Send>> {
     use futures::stream::StreamExt;
@@ -1122,7 +1122,7 @@ impl crate::LLMProvider for Anthropic {
 /// * `Ok(Some(String))` - Content token if found
 /// * `Ok(None)` - If chunk should be skipped (e.g., ping, done signal)
 /// * `Err(LLMError)` - If parsing fails
-fn parse_anthropic_sse_chunk(chunk: &str) -> Result<Option<String>, LLMError> {
+pub(crate) fn parse_anthropic_sse_chunk(chunk: &str) -> Result<Option<String>, LLMError> {
     for line in chunk.lines() {
         let line = line.trim();
         if let Some(data) = line.strip_prefix("data: ") {
@@ -1146,7 +1146,7 @@ fn parse_anthropic_sse_chunk(chunk: &str) -> Result<Option<String>, LLMError> {
 
 /// State for tracking tool use blocks during streaming
 #[derive(Debug, Default)]
-struct ToolUseState {
+pub(crate) struct ToolUseState {
     /// Tool ID
     id: String,
     /// Tool name
@@ -1173,7 +1173,7 @@ struct ToolUseState {
 /// * `Ok(Some(StreamChunk))` - A stream chunk if one was parsed
 /// * `Ok(None)` - If chunk should be skipped
 /// * `Err(LLMError)` - If parsing fails
-fn parse_anthropic_sse_chunk_with_tools(
+pub(crate) fn parse_anthropic_sse_chunk_with_tools(
     chunk: &str,
     tool_states: &mut HashMap<usize, ToolUseState>,
 ) -> Result<Option<StreamChunk>, LLMError> {

--- a/src/backends/aws/mod.rs
+++ b/src/backends/aws/mod.rs
@@ -10,9 +10,10 @@ use async_trait::async_trait;
 use aws_config::BehaviorVersion;
 use aws_sdk_bedrockruntime::{
     types::{
-        CachePointBlock, CachePointType, ContentBlock, ContentBlockDelta, ContentBlockStart, ConversationRole, ConverseStreamOutput,
-        Message, SystemContentBlock, Tool, ToolConfiguration, ToolInputSchema, ToolResultBlock,
-        ToolResultContentBlock, ToolUseBlock,
+        CachePointBlock, CachePointType, ContentBlock, ContentBlockDelta, ContentBlockStart,
+        ConversationRole, ConverseStreamOutput, JsonSchemaDefinition, Message, OutputConfig,
+        OutputFormat, OutputFormatStructure, OutputFormatType, SystemContentBlock, Tool,
+        ToolConfiguration, ToolInputSchema, ToolResultBlock, ToolResultContentBlock, ToolUseBlock,
     },
     Client as BedrockClient,
 };
@@ -27,7 +28,7 @@ use std::sync::Arc;
 use tokio::sync::OnceCell;
 
 use crate::chat::{
-    ChatMessage as LlmChatMessage, ChatProvider, StreamChunk as LlmStreamChunk, StreamChoice,
+    ChatMessage as LlmChatMessage, ChatProvider, StreamChoice, StreamChunk as LlmStreamChunk,
     StreamDelta, StreamResponse, StructuredOutputFormat, Tool as LlmTool,
     ToolChoice as LlmToolChoice,
 };
@@ -39,7 +40,7 @@ use crate::embedding::EmbeddingProvider;
 use crate::models::ModelsProvider;
 use crate::stt::SpeechToTextProvider;
 use crate::tts::TextToSpeechProvider;
-use crate::{FunctionCall, ToolCall, LLMProvider};
+use crate::{FunctionCall, LLMProvider, ToolCall};
 
 mod error;
 mod models;
@@ -81,6 +82,7 @@ struct PreparedChatRequest {
     system: Option<SystemContentBlock>,
     tool_config: Option<ToolConfiguration>,
     inference_config: aws_sdk_bedrockruntime::types::InferenceConfiguration,
+    output_config: Option<OutputConfig>,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -186,7 +188,7 @@ impl BedrockBackend {
         Ok(Self {
             client: Arc::new(OnceCell::new()),
             region,
-            model: model.map(BedrockModel::Custom),
+            model: model.map(BedrockModel::from_id),
             max_tokens,
             temperature,
             timeout_seconds,
@@ -268,7 +270,6 @@ impl BedrockBackend {
                 .set_max_tokens(request.max_tokens.or(self.max_tokens).map(|t| t as i32))
                 .set_temperature(request.temperature.map(|t| t as f32).or(self.temperature))
                 .set_top_p(request.top_p.map(|p| p as f32).or(self.top_p))
-
                 .set_stop_sequences(request.stop_sequences)
                 .build(),
         );
@@ -329,6 +330,7 @@ impl BedrockBackend {
             system,
             tool_config,
             inference_config,
+            output_config,
         } = self.prepare_chat_request(request)?;
 
         let mut converse_request = client
@@ -344,6 +346,12 @@ impl BedrockBackend {
         // Add tools if provided
         if let Some(tool_config) = tool_config {
             converse_request = converse_request.tool_config(tool_config);
+        }
+
+        // Apply native structured output config for models that support outputConfig.textFormat
+        // (e.g. Nova). For other models this will be None and the tool-based path is used instead.
+        if let Some(output_config) = output_config {
+            converse_request = converse_request.output_config(output_config);
         }
 
         // Add inference configuration
@@ -498,6 +506,7 @@ impl BedrockBackend {
             system,
             tool_config,
             inference_config,
+            output_config,
         } = self.prepare_chat_request(request)?;
 
         let mut converse_request = client
@@ -513,6 +522,11 @@ impl BedrockBackend {
         // Add tools if provided
         if let Some(tool_config) = tool_config {
             converse_request = converse_request.tool_config(tool_config);
+        }
+
+        // Apply native structured output config for models that support outputConfig.textFormat
+        if let Some(output_config) = output_config {
+            converse_request = converse_request.output_config(output_config);
         }
 
         // Add inference configuration
@@ -590,6 +604,7 @@ impl BedrockBackend {
             system,
             tool_config,
             inference_config,
+            output_config,
         } = self.prepare_chat_request(request)?;
 
         let mut converse_request = client
@@ -603,6 +618,11 @@ impl BedrockBackend {
 
         if let Some(tool_config) = tool_config {
             converse_request = converse_request.tool_config(tool_config);
+        }
+
+        // Apply native structured output config for models that support outputConfig.textFormat
+        if let Some(output_config) = output_config {
+            converse_request = converse_request.output_config(output_config);
         }
 
         converse_request = converse_request.inference_config(inference_config);
@@ -669,8 +689,7 @@ impl BedrockBackend {
                                 _ => {}
                             },
                             ConverseStreamOutput::ContentBlockStop(stop) => {
-                                let index =
-                                    usize::try_from(stop.content_block_index).unwrap_or(0);
+                                let index = usize::try_from(stop.content_block_index).unwrap_or(0);
                                 if let Some(state) = tool_states.remove(&index) {
                                     if state.started {
                                         pending.push_back(LlmStreamChunk::ToolUseComplete {
@@ -798,6 +817,8 @@ impl BedrockBackend {
         }
 
         let mut tool_choice = self.tool_choice.clone();
+        let mut output_config: Option<OutputConfig> = None;
+
         if let Some(response_format) = self.json_schema.as_ref() {
             let schema = response_format.schema.clone().ok_or_else(|| {
                 BedrockError::InvalidRequest(
@@ -805,21 +826,63 @@ impl BedrockBackend {
                 )
             })?;
 
-            let input_schema = ToolInputSchema::Json(Self::value_to_document(&schema));
-
-            let tool_spec = aws_sdk_bedrockruntime::types::ToolSpecification::builder()
-                .name("json_schema_tool")
-                .description(
-                    "Generates structured output in JSON format according to the provided schema.",
-                )
-                .input_schema(input_schema)
-                .build()
-                .map_err(|e| {
-                    BedrockError::InvalidRequest(format!("Failed to build tool spec: {:?}", e))
+            if self.model_supports(&model_id, ModelCapability::NativeStructuredOutput) {
+                // Nova and other models that advertise NativeStructuredOutput receive the schema
+                // via outputConfig.textFormat. The response arrives as ContentBlock::Text
+                // (plain JSON), so no tool-call unwrapping is needed.
+                let schema_str = serde_json::to_string(&schema).map_err(|e| {
+                    BedrockError::InvalidRequest(format!("Failed to serialize schema: {}", e))
                 })?;
 
-            bedrock_tools.push(Tool::ToolSpec(tool_spec));
-            tool_choice = Some(LlmToolChoice::Tool("json_schema_tool".to_string()));
+                let mut json_schema_builder = JsonSchemaDefinition::builder().schema(schema_str);
+                if !response_format.name.is_empty() {
+                    json_schema_builder = json_schema_builder.name(&response_format.name);
+                }
+                if let Some(desc) = &response_format.description {
+                    json_schema_builder = json_schema_builder.description(desc);
+                }
+
+                let json_schema_def = json_schema_builder.build().map_err(|e| {
+                    BedrockError::InvalidRequest(format!(
+                        "Failed to build JSON schema definition: {:?}",
+                        e
+                    ))
+                })?;
+
+                let output_format = OutputFormat::builder()
+                    .r#type(OutputFormatType::JsonSchema)
+                    .structure(OutputFormatStructure::JsonSchema(json_schema_def))
+                    .build()
+                    .map_err(|e| {
+                        BedrockError::InvalidRequest(format!(
+                            "Failed to build output format: {:?}",
+                            e
+                        ))
+                    })?;
+
+                // OutputConfig::builder().build() is infallible - the SDK builder has no
+                // required fields beyond what we set via .text_format().
+                output_config = Some(OutputConfig::builder().text_format(output_format).build());
+            } else {
+                // Fallback for models without native structured output (e.g. Claude):
+                // inject a synthetic tool and force the model to call it, then unwrap
+                // the tool call in convert_chat_response.
+                let input_schema = ToolInputSchema::Json(Self::value_to_document(&schema));
+
+                let tool_spec = aws_sdk_bedrockruntime::types::ToolSpecification::builder()
+                    .name("json_schema_tool")
+                    .description(
+                        "Generates structured output in JSON format according to the provided schema.",
+                    )
+                    .input_schema(input_schema)
+                    .build()
+                    .map_err(|e| {
+                        BedrockError::InvalidRequest(format!("Failed to build tool spec: {:?}", e))
+                    })?;
+
+                bedrock_tools.push(Tool::ToolSpec(tool_spec));
+                tool_choice = Some(LlmToolChoice::Tool("json_schema_tool".to_string()));
+            }
         }
 
         if let Some(tools) = &self.tools {
@@ -905,6 +968,7 @@ impl BedrockBackend {
             system,
             tool_config,
             inference_config,
+            output_config,
         })
     }
 
@@ -1384,7 +1448,12 @@ impl ChatProvider for BedrockBackend {
         &self,
         messages: &[LlmChatMessage],
     ) -> std::result::Result<
-        Pin<Box<dyn Stream<Item = std::result::Result<StreamResponse, crate::error::LLMError>> + Send>>,
+        Pin<
+            Box<
+                dyn Stream<Item = std::result::Result<StreamResponse, crate::error::LLMError>>
+                    + Send,
+            >,
+        >,
         crate::error::LLMError,
     > {
         let aws_messages: Vec<ChatMessage> = messages
@@ -1434,17 +1503,15 @@ impl ChatProvider for BedrockBackend {
                     }],
                     usage: None,
                 })),
-                Ok(LlmStreamChunk::ToolUseComplete { tool_call, .. }) => {
-                    Some(Ok(StreamResponse {
-                        choices: vec![StreamChoice {
-                            delta: StreamDelta {
-                                content: None,
-                                tool_calls: Some(vec![tool_call]),
-                            },
-                        }],
-                        usage: None,
-                    }))
-                }
+                Ok(LlmStreamChunk::ToolUseComplete { tool_call, .. }) => Some(Ok(StreamResponse {
+                    choices: vec![StreamChoice {
+                        delta: StreamDelta {
+                            content: None,
+                            tool_calls: Some(vec![tool_call]),
+                        },
+                    }],
+                    usage: None,
+                })),
                 Ok(LlmStreamChunk::Done { .. }) => None,
                 Ok(_) => None,
                 Err(e) => Some(Err(crate::error::LLMError::ProviderError(e.to_string()))),
@@ -1459,7 +1526,12 @@ impl ChatProvider for BedrockBackend {
         messages: &[LlmChatMessage],
         tools: Option<&[LlmTool]>,
     ) -> std::result::Result<
-        Pin<Box<dyn Stream<Item = std::result::Result<LlmStreamChunk, crate::error::LLMError>> + Send>>,
+        Pin<
+            Box<
+                dyn Stream<Item = std::result::Result<LlmStreamChunk, crate::error::LLMError>>
+                    + Send,
+            >,
+        >,
         crate::error::LLMError,
     > {
         let aws_messages: Vec<ChatMessage> = messages
@@ -1740,5 +1812,124 @@ streaming = true
         let tool_call = state.to_tool_call();
 
         assert_eq!(tool_call.function.arguments, "{}");
+    }
+
+    #[test]
+    fn test_prepare_chat_request_nova_uses_output_config_not_tool() {
+        // Nova models must use outputConfig.textFormat for structured output,
+        // not the synthetic json_schema_tool workaround.
+        let backend = BedrockBackend::new(
+            "us-east-1".to_string(),
+            Some("amazon.nova-pro-v1:0".to_string()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(crate::chat::StructuredOutputFormat {
+                name: "result".to_string(),
+                description: None,
+                schema: Some(serde_json::json!({"type": "object", "properties": {}})),
+                strict: None,
+            }),
+        )
+        .unwrap();
+
+        let request = ChatRequest::new(vec![ChatMessage::user("hello")]);
+        let prepared = backend.prepare_chat_request(request).unwrap();
+
+        // output_config must be set for the native path
+        assert!(prepared.output_config.is_some());
+        // tool_config must be None -- no synthetic json_schema_tool should be injected
+        assert!(prepared.tool_config.is_none());
+    }
+
+    #[test]
+    fn test_prepare_chat_request_claude_uses_tool_not_output_config() {
+        // Claude (and other non-Nova models) must use the tool-based workaround.
+        let backend = BedrockBackend::new(
+            "us-east-1".to_string(),
+            Some("us.anthropic.claude-sonnet-4-0-v1:0".to_string()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(crate::chat::StructuredOutputFormat {
+                name: "result".to_string(),
+                description: None,
+                schema: Some(serde_json::json!({"type": "object", "properties": {}})),
+                strict: None,
+            }),
+        )
+        .unwrap();
+
+        let request = ChatRequest::new(vec![ChatMessage::user("hello")]);
+        let prepared = backend.prepare_chat_request(request).unwrap();
+
+        // tool_config must contain the synthetic json_schema_tool
+        let tool_config = prepared
+            .tool_config
+            .expect("tool_config should be present for Claude");
+        assert!(tool_config
+            .tools()
+            .iter()
+            .any(|t| matches!(t, Tool::ToolSpec(spec) if spec.name() == "json_schema_tool")));
+        // output_config must not be set
+        assert!(prepared.output_config.is_none());
+    }
+
+    #[test]
+    fn test_prepare_chat_request_nova_with_real_tools_and_schema() {
+        // When Nova has both real user tools AND json_schema set, real tools go into
+        // tool_config and the schema goes into output_config. Both can coexist because
+        // the synthetic json_schema_tool is never injected on the native path.
+        let backend = BedrockBackend::new(
+            "us-east-1".to_string(),
+            Some("amazon.nova-pro-v1:0".to_string()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(crate::chat::StructuredOutputFormat {
+                name: "result".to_string(),
+                description: None,
+                schema: Some(serde_json::json!({"type": "object", "properties": {}})),
+                strict: None,
+            }),
+        )
+        .unwrap();
+
+        let tools = vec![ToolDefinition {
+            name: "get_weather".to_string(),
+            description: "Get weather".to_string(),
+            input_schema: serde_json::json!({"type": "object", "properties": {}}),
+            cache_control: None,
+        }];
+
+        let request = ChatRequest::new(vec![ChatMessage::user("hello")]).with_tools(tools);
+        let prepared = backend.prepare_chat_request(request).unwrap();
+
+        assert!(prepared.output_config.is_some());
+        let tool_config = prepared
+            .tool_config
+            .expect("real tools should produce tool_config");
+        let tools = tool_config.tools();
+        // Only the real tool, no json_schema_tool pollution
+        assert_eq!(tools.len(), 1);
+        assert!(matches!(tools[0], Tool::ToolSpec(ref spec) if spec.name() == "get_weather"));
     }
 }

--- a/src/backends/aws/models.rs
+++ b/src/backends/aws/models.rs
@@ -79,6 +79,16 @@ pub enum DirectModel {
     #[serde(rename = "amazon.titan-embed-text-v1")]
     TitanEmbedV1,
 
+    // Amazon Nova models
+    #[serde(rename = "amazon.nova-pro-v1:0")]
+    NovaProV1,
+
+    #[serde(rename = "amazon.nova-lite-v1:0")]
+    NovaLiteV1,
+
+    #[serde(rename = "amazon.nova-micro-v1:0")]
+    NovaMicroV1,
+
     // Cohere models
     #[serde(rename = "cohere.command-r-plus-v1:0")]
     CohereCommandRPlus,
@@ -121,6 +131,16 @@ pub enum CrossRegionModel {
 
     #[serde(rename = "claude-3-haiku-20240307-v1:0")]
     ClaudeHaiku3,
+
+    // Amazon Nova models
+    #[serde(rename = "nova-pro-v1:0")]
+    NovaProV1,
+
+    #[serde(rename = "nova-lite-v1:0")]
+    NovaLiteV1,
+
+    #[serde(rename = "nova-micro-v1:0")]
+    NovaMicroV1,
 
     // Mistral models
     #[serde(rename = "pixtral-large-2502-v1:0")]
@@ -305,6 +325,9 @@ impl DirectModel {
             Self::TitanTextLite => "amazon.titan-text-lite-v1",
             Self::TitanEmbedV2 => "amazon.titan-embed-text-v2:0",
             Self::TitanEmbedV1 => "amazon.titan-embed-text-v1",
+            Self::NovaProV1 => "amazon.nova-pro-v1:0",
+            Self::NovaLiteV1 => "amazon.nova-lite-v1:0",
+            Self::NovaMicroV1 => "amazon.nova-micro-v1:0",
             Self::CohereCommandRPlus => "cohere.command-r-plus-v1:0",
             Self::CohereCommandR => "cohere.command-r-v1:0",
             Self::CohereEmbedV3 => "cohere.embed-english-v3",
@@ -333,6 +356,9 @@ impl DirectModel {
             "amazon.titan-text-lite-v1" => Some(Self::TitanTextLite),
             "amazon.titan-embed-text-v2:0" => Some(Self::TitanEmbedV2),
             "amazon.titan-embed-text-v1" => Some(Self::TitanEmbedV1),
+            "amazon.nova-pro-v1:0" => Some(Self::NovaProV1),
+            "amazon.nova-lite-v1:0" => Some(Self::NovaLiteV1),
+            "amazon.nova-micro-v1:0" => Some(Self::NovaMicroV1),
             "cohere.command-r-plus-v1:0" => Some(Self::CohereCommandRPlus),
             "cohere.command-r-v1:0" => Some(Self::CohereCommandR),
             "cohere.embed-english-v3" => Some(Self::CohereEmbedV3),
@@ -353,6 +379,9 @@ impl CrossRegionModel {
             Self::ClaudeOpus3 => "claude-3-opus-20240229-v1:0",
             Self::ClaudeSonnet35 => "claude-3-5-sonnet-20240620-v1:0",
             Self::ClaudeHaiku3 => "claude-3-haiku-20240307-v1:0",
+            Self::NovaProV1 => "nova-pro-v1:0",
+            Self::NovaLiteV1 => "nova-lite-v1:0",
+            Self::NovaMicroV1 => "nova-micro-v1:0",
             Self::MistralPixtralLarge => "pixtral-large-2502-v1:0",
             Self::CohereEmbedV4 => "embed-v4:0",
         }
@@ -366,6 +395,7 @@ impl CrossRegionModel {
             | Self::ClaudeOpus3
             | Self::ClaudeSonnet35
             | Self::ClaudeHaiku3 => "anthropic",
+            Self::NovaProV1 | Self::NovaLiteV1 | Self::NovaMicroV1 => "amazon",
             Self::MistralPixtralLarge => "mistral",
             Self::CohereEmbedV4 => "cohere",
         }
@@ -387,6 +417,9 @@ impl CrossRegionModel {
                 Some(Self::ClaudeSonnet35)
             }
             ("anthropic", id) if id.contains("claude-3-haiku") => Some(Self::ClaudeHaiku3),
+            ("amazon", id) if id.contains("nova-pro") => Some(Self::NovaProV1),
+            ("amazon", id) if id.contains("nova-lite") => Some(Self::NovaLiteV1),
+            ("amazon", id) if id.contains("nova-micro") => Some(Self::NovaMicroV1),
             ("mistral", id) if id.contains("pixtral-large") => Some(Self::MistralPixtralLarge),
             ("cohere", id) if id.contains("embed-v4") => Some(Self::CohereEmbedV4),
             _ => None,
@@ -413,6 +446,9 @@ impl BedrockModel {
             ModelCapability::Vision => self.supports_vision_impl(),
             ModelCapability::ToolUse => self.supports_tools_impl(),
             ModelCapability::Streaming => self.is_text_model() || self.is_chat_model(),
+            ModelCapability::NativeStructuredOutput => {
+                self.supports_native_structured_output_impl()
+            }
         }
     }
 
@@ -450,6 +486,14 @@ impl BedrockModel {
         match self.inner_model() {
             InnerModel::Direct(model) => model.supports_tools(),
             InnerModel::CrossRegion(model) => model.supports_tools(),
+            _ => false,
+        }
+    }
+
+    fn supports_native_structured_output_impl(&self) -> bool {
+        match self.inner_model() {
+            InnerModel::Direct(model) => model.supports_native_structured_output(),
+            InnerModel::CrossRegion(model) => model.supports_native_structured_output(),
             _ => false,
         }
     }
@@ -505,6 +549,8 @@ impl DirectModel {
                 | Self::ClaudeHaiku3
                 | Self::Llama32_90B
                 | Self::Llama32_11B
+                | Self::NovaProV1
+                | Self::NovaLiteV1
         )
     }
 
@@ -520,7 +566,14 @@ impl DirectModel {
                 | Self::CohereCommandRPlus
                 | Self::CohereCommandR
                 | Self::MistralLarge
+                | Self::NovaProV1
+                | Self::NovaLiteV1
+                | Self::NovaMicroV1
         )
+    }
+
+    fn supports_native_structured_output(&self) -> bool {
+        matches!(self, Self::NovaProV1 | Self::NovaLiteV1 | Self::NovaMicroV1)
     }
 
     fn max_output_tokens(&self) -> u32 {
@@ -534,6 +587,7 @@ impl DirectModel {
             Self::TitanTextLite => 4096,
             Self::CohereCommandRPlus | Self::CohereCommandR => 4096,
             Self::MistralLarge | Self::MistralSmall => 8192,
+            Self::NovaProV1 | Self::NovaLiteV1 | Self::NovaMicroV1 => 5120,
             _ => 0,
         }
     }
@@ -551,6 +605,8 @@ impl DirectModel {
             Self::TitanTextExpress | Self::TitanTextLite => 8_000,
             Self::CohereCommandRPlus | Self::CohereCommandR => 128_000,
             Self::MistralLarge | Self::MistralSmall => 128_000,
+            Self::NovaProV1 | Self::NovaLiteV1 => 300_000,
+            Self::NovaMicroV1 => 128_000,
             _ => 0,
         }
     }
@@ -575,6 +631,8 @@ impl CrossRegionModel {
                 | Self::ClaudeSonnet35
                 | Self::ClaudeHaiku3
                 | Self::MistralPixtralLarge
+                | Self::NovaProV1
+                | Self::NovaLiteV1
         )
     }
 
@@ -588,7 +646,14 @@ impl CrossRegionModel {
                 | Self::ClaudeSonnet35
                 | Self::ClaudeHaiku3
                 | Self::MistralPixtralLarge
+                | Self::NovaProV1
+                | Self::NovaLiteV1
+                | Self::NovaMicroV1
         )
+    }
+
+    fn supports_native_structured_output(&self) -> bool {
+        matches!(self, Self::NovaProV1 | Self::NovaLiteV1 | Self::NovaMicroV1)
     }
 
     fn max_output_tokens(&self) -> u32 {
@@ -597,6 +662,7 @@ impl CrossRegionModel {
             Self::ClaudeOpus3 | Self::ClaudeSonnet35 => 8192,
             Self::ClaudeHaiku3 => 4096,
             Self::MistralPixtralLarge => 8192,
+            Self::NovaProV1 | Self::NovaLiteV1 | Self::NovaMicroV1 => 5120,
             Self::CohereEmbedV4 => 0,
         }
     }
@@ -606,6 +672,8 @@ impl CrossRegionModel {
             Self::ClaudeSonnet4 | Self::ClaudeSonnet45 | Self::ClaudeSonnet35V2 => 200_000,
             Self::ClaudeOpus3 | Self::ClaudeSonnet35 | Self::ClaudeHaiku3 => 200_000,
             Self::MistralPixtralLarge => 128_000,
+            Self::NovaProV1 | Self::NovaLiteV1 => 300_000,
+            Self::NovaMicroV1 => 128_000,
             Self::CohereEmbedV4 => 0,
         }
     }
@@ -649,6 +717,11 @@ pub enum ModelCapability {
 
     /// Streaming responses
     Streaming,
+
+    /// Native structured output via outputConfig.textFormat (Bedrock Converse).
+    /// Models with this capability receive JSON directly without the synthetic
+    /// json_schema_tool workaround needed by Claude and other models.
+    NativeStructuredOutput,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -741,6 +814,8 @@ pub struct ModelCapabilityOverride {
     pub tool_use: Option<bool>,
     #[serde(default)]
     pub streaming: Option<bool>,
+    #[serde(default)]
+    pub native_structured_output: Option<bool>,
 }
 
 impl ModelCapabilityOverride {
@@ -752,6 +827,7 @@ impl ModelCapabilityOverride {
             ModelCapability::Vision => self.vision,
             ModelCapability::ToolUse => self.tool_use,
             ModelCapability::Streaming => self.streaming,
+            ModelCapability::NativeStructuredOutput => self.native_structured_output,
         }
     }
 }
@@ -759,6 +835,114 @@ impl ModelCapabilityOverride {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_nova_model_ids() {
+        let nova_pro = BedrockModel::Direct(DirectModel::NovaProV1);
+        assert_eq!(nova_pro.model_id(), "amazon.nova-pro-v1:0");
+
+        let nova_lite = BedrockModel::Direct(DirectModel::NovaLiteV1);
+        assert_eq!(nova_lite.model_id(), "amazon.nova-lite-v1:0");
+
+        let nova_micro = BedrockModel::Direct(DirectModel::NovaMicroV1);
+        assert_eq!(nova_micro.model_id(), "amazon.nova-micro-v1:0");
+
+        let nova_pro_eu = BedrockModel::eu(CrossRegionModel::NovaProV1);
+        assert!(nova_pro_eu.model_id().contains("nova-pro-v1:0"));
+        assert!(nova_pro_eu.model_id().contains("amazon"));
+    }
+
+    #[test]
+    fn test_nova_from_id() {
+        let model = BedrockModel::from_id("amazon.nova-pro-v1:0");
+        assert!(matches!(
+            model,
+            BedrockModel::Direct(DirectModel::NovaProV1)
+        ));
+
+        let model = BedrockModel::from_id("amazon.nova-lite-v1:0");
+        assert!(matches!(
+            model,
+            BedrockModel::Direct(DirectModel::NovaLiteV1)
+        ));
+
+        let model = BedrockModel::from_id("amazon.nova-micro-v1:0");
+        assert!(matches!(
+            model,
+            BedrockModel::Direct(DirectModel::NovaMicroV1)
+        ));
+    }
+
+    #[test]
+    fn test_nova_capabilities() {
+        let nova_pro = BedrockModel::Direct(DirectModel::NovaProV1);
+        assert!(nova_pro.supports(ModelCapability::Chat));
+        assert!(nova_pro.supports(ModelCapability::Vision));
+        assert!(nova_pro.supports(ModelCapability::ToolUse));
+        assert!(nova_pro.supports(ModelCapability::NativeStructuredOutput));
+        assert!(!nova_pro.supports(ModelCapability::Embeddings));
+
+        let nova_lite = BedrockModel::Direct(DirectModel::NovaLiteV1);
+        assert!(nova_lite.supports(ModelCapability::Vision));
+        assert!(nova_lite.supports(ModelCapability::NativeStructuredOutput));
+
+        let nova_micro = BedrockModel::Direct(DirectModel::NovaMicroV1);
+        assert!(!nova_micro.supports(ModelCapability::Vision));
+        assert!(nova_micro.supports(ModelCapability::ToolUse));
+        assert!(nova_micro.supports(ModelCapability::NativeStructuredOutput));
+
+        let nova_pro_eu = BedrockModel::eu(CrossRegionModel::NovaProV1);
+        assert!(nova_pro_eu.supports(ModelCapability::NativeStructuredOutput));
+        assert!(nova_pro_eu.supports(ModelCapability::ToolUse));
+
+        let nova_micro_eu = BedrockModel::eu(CrossRegionModel::NovaMicroV1);
+        assert!(nova_micro_eu.supports(ModelCapability::NativeStructuredOutput));
+    }
+
+    #[test]
+    fn test_claude_does_not_support_native_structured_output() {
+        let claude = BedrockModel::Direct(DirectModel::ClaudeSonnet4);
+        assert!(!claude.supports(ModelCapability::NativeStructuredOutput));
+
+        let claude_eu = BedrockModel::eu(CrossRegionModel::ClaudeSonnet4);
+        assert!(!claude_eu.supports(ModelCapability::NativeStructuredOutput));
+    }
+
+    #[test]
+    fn test_nova_context_windows() {
+        let nova_pro = BedrockModel::Direct(DirectModel::NovaProV1);
+        assert_eq!(nova_pro.context_window(), 300_000);
+
+        let nova_lite = BedrockModel::Direct(DirectModel::NovaLiteV1);
+        assert_eq!(nova_lite.context_window(), 300_000);
+
+        let nova_micro = BedrockModel::Direct(DirectModel::NovaMicroV1);
+        assert_eq!(nova_micro.context_window(), 128_000);
+
+        let nova_pro_eu = BedrockModel::eu(CrossRegionModel::NovaProV1);
+        assert_eq!(nova_pro_eu.context_window(), 300_000);
+    }
+
+    #[test]
+    fn test_capability_override_native_structured_output() {
+        let mut override_entry = ModelCapabilityOverride::default();
+        assert_eq!(
+            override_entry.supports(ModelCapability::NativeStructuredOutput),
+            None
+        );
+
+        override_entry.native_structured_output = Some(true);
+        assert_eq!(
+            override_entry.supports(ModelCapability::NativeStructuredOutput),
+            Some(true)
+        );
+
+        override_entry.native_structured_output = Some(false);
+        assert_eq!(
+            override_entry.supports(ModelCapability::NativeStructuredOutput),
+            Some(false)
+        );
+    }
 
     #[test]
     fn test_model_id() {

--- a/src/backends/aws/models.rs
+++ b/src/backends/aws/models.rs
@@ -232,9 +232,26 @@ impl BedrockModel {
             }
         }
 
-        // Try to match against direct models
+        // Try to match against direct models (exact match first)
         if let Some(direct) = DirectModel::from_id(&id) {
             return Self::Direct(direct);
+        }
+
+        // Try stripping a geo inference-profile prefix and retrying.
+        // IDs like "us.amazon.nova-pro-v1:0", "eu.amazon.nova-lite-v1:0", or a future
+        // "sa.amazon.nova-pro-v1:0" are functionally identical to the unprefixed form
+        // for capability checks. We detect the prefix by looking for a short all-alpha
+        // segment before the first dot (geo codes are 2-3 chars; vendor names are longer).
+        if let Some(dot) = id.find('.') {
+            let prefix = &id[..dot];
+            if !prefix.is_empty()
+                && prefix.len() <= 3
+                && prefix.chars().all(|c| c.is_ascii_alphabetic())
+            {
+                if let Some(direct) = DirectModel::from_id(&id[dot + 1..]) {
+                    return Self::Direct(direct);
+                }
+            }
         }
 
         // Otherwise treat as custom
@@ -871,6 +888,59 @@ mod tests {
             model,
             BedrockModel::Direct(DirectModel::NovaMicroV1)
         ));
+    }
+
+    #[test]
+    fn test_nova_geo_prefixed_from_id() {
+        // Geo-prefixed inference profile IDs must resolve to the same Direct variant
+        // so that capability checks (NativeStructuredOutput, ToolUse, etc.) work correctly.
+        // Includes a hypothetical future prefix ("sa") to verify we don't rely on an
+        // enumerated allowlist.
+        for prefix in ["us.", "eu.", "ap.", "sa."] {
+            let id = format!("{}amazon.nova-pro-v1:0", prefix);
+            assert!(
+                matches!(
+                    BedrockModel::from_id(&id),
+                    BedrockModel::Direct(DirectModel::NovaProV1)
+                ),
+                "{id} should resolve to NovaProV1"
+            );
+
+            let id = format!("{}amazon.nova-lite-v1:0", prefix);
+            assert!(
+                matches!(
+                    BedrockModel::from_id(&id),
+                    BedrockModel::Direct(DirectModel::NovaLiteV1)
+                ),
+                "{id} should resolve to NovaLiteV1"
+            );
+
+            let id = format!("{}amazon.nova-micro-v1:0", prefix);
+            assert!(
+                matches!(
+                    BedrockModel::from_id(&id),
+                    BedrockModel::Direct(DirectModel::NovaMicroV1)
+                ),
+                "{id} should resolve to NovaMicroV1"
+            );
+        }
+    }
+
+    #[test]
+    fn test_nova_geo_prefixed_native_structured_output_capability() {
+        // The whole point of the fix: geo-prefixed Nova IDs must report
+        // NativeStructuredOutput = true so prepare_chat_request uses outputConfig.textFormat.
+        for id in [
+            "us.amazon.nova-pro-v1:0",
+            "eu.amazon.nova-lite-v1:0",
+            "ap.amazon.nova-micro-v1:0",
+        ] {
+            let model = BedrockModel::from_id(id);
+            assert!(
+                model.supports(ModelCapability::NativeStructuredOutput),
+                "{id} should support NativeStructuredOutput"
+            );
+        }
     }
 
     #[test]

--- a/src/backends/google.rs
+++ b/src/backends/google.rs
@@ -100,7 +100,7 @@ impl Serialize for GoogleServiceTier {
 /// Configuration for the Google Gemini client.
 #[derive(Debug)]
 pub struct GoogleConfig {
-    /// API key for authentication with Google.
+    /// API key for authentication with Google (or GCP Bearer token when vertex_ai_base_url is set).
     pub api_key: String,
     /// Model identifier (e.g., "gemini-pro").
     pub model: String,
@@ -122,6 +122,9 @@ pub struct GoogleConfig {
     pub tools: Option<Vec<Tool>>,
     /// Service tier for inference (standard, flex, or priority).
     pub service_tier: Option<GoogleServiceTier>,
+    /// Vertex AI base URL. When set, uses Bearer auth and Vertex AI endpoints.
+    /// Format: https://{location}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location}
+    pub vertex_ai_base_url: Option<String>,
 }
 
 /// Client for interacting with Google's Gemini API.
@@ -584,6 +587,30 @@ impl Google {
         tools: Option<Vec<Tool>>,
         service_tier: Option<GoogleServiceTier>,
     ) -> Self {
+        Self::with_client_and_vertex(
+            client, api_key, model, max_tokens, temperature, timeout_seconds,
+            system, top_p, top_k, json_schema, tools, service_tier, None,
+        )
+    }
+
+    /// Creates a Google Gemini client, optionally routing to a Vertex AI endpoint.
+    /// When `vertex_ai_base_url` is `Some`, `api_key` is treated as a Bearer token.
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_client_and_vertex(
+        client: Client,
+        api_key: impl Into<String>,
+        model: Option<String>,
+        max_tokens: Option<u32>,
+        temperature: Option<f32>,
+        timeout_seconds: Option<u64>,
+        system: Option<String>,
+        top_p: Option<f32>,
+        top_k: Option<u32>,
+        json_schema: Option<StructuredOutputFormat>,
+        tools: Option<Vec<Tool>>,
+        service_tier: Option<GoogleServiceTier>,
+        vertex_ai_base_url: Option<String>,
+    ) -> Self {
         Self {
             config: Arc::new(GoogleConfig {
                 api_key: api_key.into(),
@@ -597,9 +624,56 @@ impl Google {
                 json_schema,
                 tools,
                 service_tier,
+                vertex_ai_base_url,
             }),
             client,
         }
+    }
+
+    fn generate_content_url(&self) -> String {
+        match &self.config.vertex_ai_base_url {
+            Some(base) => format!(
+                "{}/publishers/google/models/{}:generateContent",
+                base, self.config.model
+            ),
+            None => format!(
+                "https://generativelanguage.googleapis.com/v1beta/models/{}:generateContent?key={}",
+                self.config.model, self.config.api_key
+            ),
+        }
+    }
+
+    fn stream_generate_content_url(&self) -> String {
+        match &self.config.vertex_ai_base_url {
+            Some(base) => format!(
+                "{}/publishers/google/models/{}:streamGenerateContent?alt=sse",
+                base, self.config.model
+            ),
+            None => format!(
+                "https://generativelanguage.googleapis.com/v1beta/models/{}:streamGenerateContent?alt=sse&key={}",
+                self.config.model, self.config.api_key
+            ),
+        }
+    }
+
+    fn embed_content_url(&self) -> String {
+        match &self.config.vertex_ai_base_url {
+            Some(base) => format!(
+                "{}/publishers/google/models/{}:embedContent",
+                base, self.config.model
+            ),
+            None => format!(
+                "https://generativelanguage.googleapis.com/v1beta/models/{}:embedContent?key={}",
+                self.config.model, self.config.api_key
+            ),
+        }
+    }
+
+    fn apply_auth(&self, mut req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        if self.config.vertex_ai_base_url.is_some() {
+            req = req.header("Authorization", format!("Bearer {}", self.config.api_key));
+        }
+        req
     }
 
     pub fn api_key(&self) -> &str {
@@ -787,13 +861,8 @@ impl ChatProvider for Google {
             }
         }
 
-        let url = format!(
-            "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={key}",
-            model = self.config.model,
-            key = self.config.api_key
-        );
-
-        let mut request = self.client.post(&url).json(&req_body);
+        let url = self.generate_content_url();
+        let mut request = self.apply_auth(self.client.post(&url).json(&req_body));
         if let Some(timeout) = self.config.timeout_seconds {
             request = request.timeout(std::time::Duration::from_secs(timeout));
         }
@@ -962,15 +1031,8 @@ impl ChatProvider for Google {
             }
         }
 
-        let url = format!(
-            "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={key}",
-            model = self.config.model,
-            key = self.config.api_key
-
-        );
-
-        let mut request = self.client.post(&url).json(&req_body);
-
+        let url = self.generate_content_url();
+        let mut request = self.apply_auth(self.client.post(&url).json(&req_body));
         if let Some(timeout) = self.config.timeout_seconds {
             request = request.timeout(std::time::Duration::from_secs(timeout));
         }
@@ -1108,13 +1170,8 @@ impl ChatProvider for Google {
             tools: None,
             service_tier: self.config.service_tier.as_ref(),
         };
-        let url = format!(
-            "https://generativelanguage.googleapis.com/v1beta/models/{model}:streamGenerateContent?alt=sse&key={key}",
-            model = self.config.model,
-            key = self.config.api_key
-        );
-
-        let mut request = self.client.post(&url).json(&req_body);
+        let url = self.stream_generate_content_url();
+        let mut request = self.apply_auth(self.client.post(&url).json(&req_body));
         if let Some(timeout) = self.config.timeout_seconds {
             request = request.timeout(std::time::Duration::from_secs(timeout));
         }
@@ -1165,22 +1222,17 @@ impl EmbeddingProvider for Google {
 
         // Process each text separately as Gemini API accepts one text at a time
         for text in texts {
+            let embed_model = format!("models/{}", self.config.model);
             let req_body = GoogleEmbeddingRequest {
-                model: "models/text-embedding-004",
+                model: &embed_model,
                 content: GoogleEmbeddingContent {
                     parts: vec![GoogleContentPart::Text(&text)],
                 },
             };
 
-            let url = format!(
-                "https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:embedContent?key={}",
-                self.config.api_key
-            );
-
+            let url = self.embed_content_url();
             let resp = self
-                .client
-                .post(&url)
-                .json(&req_body)
+                .apply_auth(self.client.post(&url).json(&req_body))
                 .send()
                 .await?
                 .error_for_status()?;
@@ -1371,12 +1423,18 @@ impl ModelsProvider for Google {
             return Err(LLMError::AuthError("Missing Google API key".to_string()));
         }
 
-        let url = format!(
-            "https://generativelanguage.googleapis.com/v1beta/models?key={}",
-            self.config.api_key
-        );
-
-        let resp = self.client.get(&url).send().await?.error_for_status()?;
+        let url = match &self.config.vertex_ai_base_url {
+            Some(base) => format!("{}/publishers/google/models", base),
+            None => format!(
+                "https://generativelanguage.googleapis.com/v1beta/models?key={}",
+                self.config.api_key
+            ),
+        };
+        let resp = self
+            .apply_auth(self.client.get(&url))
+            .send()
+            .await?
+            .error_for_status()?;
 
         let result: GoogleModelListResponse = resp.json().await?;
         Ok(Box::new(result))

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -42,3 +42,6 @@ pub mod huggingface;
 
 #[cfg(feature = "bedrock")]
 pub mod aws;
+
+#[cfg(feature = "vertex_ai")]
+pub mod vertex_ai;

--- a/src/backends/vertex_ai.rs
+++ b/src/backends/vertex_ai.rs
@@ -1,0 +1,639 @@
+//! Vertex AI Anthropic client (Claude models via Google Cloud).
+//!
+//! Pass `base_url` as:
+//!   https://{location}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location}
+//! Pass `api_key` as a GCP Bearer token (workload identity or ADC).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::{
+    builder::SystemPrompt,
+    chat::{
+        ChatMessage, ChatProvider, ChatResponse, ChatRole, MessageType, StreamChunk, Tool,
+        ToolChoice, Usage,
+    },
+    completion::{CompletionProvider, CompletionRequest, CompletionResponse},
+    embedding::EmbeddingProvider,
+    error::LLMError,
+    models::{ModelListRequest, ModelListResponse, ModelsProvider},
+    stt::SpeechToTextProvider,
+    tts::TextToSpeechProvider,
+    FunctionCall, ToolCall,
+};
+use async_trait::async_trait;
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use futures::stream::Stream;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug)]
+pub struct VertexAIConfig {
+    /// GCP Bearer token (from workload identity / ADC).
+    pub token: String,
+    /// https://{location}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location}
+    pub base_url: String,
+    pub model: String,
+    pub max_tokens: u32,
+    pub temperature: f32,
+    pub timeout_seconds: u64,
+    pub system: SystemPrompt,
+    pub top_p: Option<f32>,
+    pub top_k: Option<u32>,
+    pub tools: Option<Vec<Tool>>,
+    pub tool_choice: Option<ToolChoice>,
+    pub reasoning: bool,
+    pub thinking_budget_tokens: Option<u32>,
+}
+
+#[derive(Debug, Clone)]
+pub struct VertexAI {
+    pub config: Arc<VertexAIConfig>,
+    pub client: Client,
+}
+
+// ── Vertex AI request/response types (Anthropic Messages API format) ──────────
+
+#[derive(Serialize, Debug)]
+struct VertexAIRequest<'a> {
+    anthropic_version: &'a str,
+    messages: Vec<VAMessage<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system: Option<VASystemPrompt<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stream: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    top_p: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    top_k: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tools: Option<Vec<VATool<'a>>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_choice: Option<HashMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thinking: Option<VAThinking>,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(untagged)]
+enum VASystemPrompt<'a> {
+    String(&'a str),
+    Messages(&'a [crate::builder::SystemContent]),
+}
+
+#[derive(Serialize, Debug)]
+struct VATool<'a> {
+    name: &'a str,
+    description: &'a str,
+    #[serde(rename = "input_schema")]
+    schema: &'a Value,
+}
+
+#[derive(Serialize, Debug)]
+struct VAThinking {
+    #[serde(rename = "type")]
+    thinking_type: String,
+    budget_tokens: u32,
+}
+
+#[derive(Serialize, Debug)]
+struct VAMessage<'a> {
+    role: &'a str,
+    content: Vec<VAContent<'a>>,
+}
+
+#[derive(Serialize, Debug)]
+struct VAContent<'a> {
+    #[serde(rename = "type")]
+    content_type: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    text: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source: Option<VAImageSource<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "id")]
+    tool_use_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "name")]
+    tool_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "input")]
+    tool_input: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "tool_use_id")]
+    tool_result_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "content")]
+    tool_output: Option<String>,
+}
+
+#[derive(Serialize, Debug)]
+struct VAImageSource<'a> {
+    #[serde(rename = "type")]
+    source_type: &'a str,
+    media_type: &'a str,
+    data: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct VAResponse {
+    content: Vec<VAResponseContent>,
+    usage: Option<VAUsage>,
+}
+
+#[derive(Deserialize, Debug)]
+struct VAUsage {
+    input_tokens: u32,
+    output_tokens: u32,
+    #[allow(dead_code)]
+    cache_creation_input_tokens: Option<u32>,
+    #[allow(dead_code)]
+    cache_read_input_tokens: Option<u32>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct VAResponseContent {
+    text: Option<String>,
+    #[serde(rename = "type")]
+    content_type: Option<String>,
+    thinking: Option<String>,
+    name: Option<String>,
+    input: Option<Value>,
+    id: Option<String>,
+}
+
+impl ChatResponse for VAResponse {
+    fn text(&self) -> Option<String> {
+        Some(
+            self.content
+                .iter()
+                .filter_map(|c| {
+                    if c.content_type == Some("text".to_string()) || c.content_type.is_none() {
+                        c.text.clone()
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n"),
+        )
+    }
+
+    fn thinking(&self) -> Option<String> {
+        self.content
+            .iter()
+            .find(|c| c.content_type == Some("thinking".to_string()))
+            .and_then(|c| c.thinking.clone())
+    }
+
+    fn tool_calls(&self) -> Option<Vec<ToolCall>> {
+        let calls: Vec<ToolCall> = self
+            .content
+            .iter()
+            .filter_map(|c| {
+                if c.content_type == Some("tool_use".to_string()) {
+                    Some(ToolCall {
+                        id: c.id.clone().unwrap_or_default(),
+                        call_type: "function".to_string(),
+                        function: FunctionCall {
+                            name: c.name.clone().unwrap_or_default(),
+                            arguments: serde_json::to_string(
+                                &c.input.clone().unwrap_or(Value::Null),
+                            )
+                            .unwrap_or_default(),
+                        },
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect();
+        if calls.is_empty() { None } else { Some(calls) }
+    }
+
+    fn usage(&self) -> Option<Usage> {
+        self.usage.as_ref().map(|u| Usage {
+            prompt_tokens: u.input_tokens,
+            completion_tokens: u.output_tokens,
+            total_tokens: u.input_tokens + u.output_tokens,
+            completion_tokens_details: None,
+            prompt_tokens_details: None,
+        })
+    }
+}
+
+impl std::fmt::Display for VAResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.text().unwrap_or_default())
+    }
+}
+
+// ── VertexAI impl ─────────────────────────────────────────────────────────────
+
+impl VertexAI {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        token: impl Into<String>,
+        base_url: impl Into<String>,
+        model: Option<String>,
+        max_tokens: Option<u32>,
+        temperature: Option<f32>,
+        timeout_seconds: Option<u64>,
+        system: Option<SystemPrompt>,
+        top_p: Option<f32>,
+        top_k: Option<u32>,
+        tools: Option<Vec<Tool>>,
+        tool_choice: Option<ToolChoice>,
+        reasoning: Option<bool>,
+        thinking_budget_tokens: Option<u32>,
+    ) -> Self {
+        let timeout = timeout_seconds.unwrap_or(60);
+        let mut builder = Client::builder();
+        if timeout > 0 {
+            builder = builder.timeout(std::time::Duration::from_secs(timeout));
+        }
+        Self {
+            config: Arc::new(VertexAIConfig {
+                token: token.into(),
+                base_url: base_url.into(),
+                model: model.unwrap_or_else(|| "claude-sonnet-4-5".to_string()),
+                max_tokens: max_tokens.unwrap_or(4096),
+                temperature: temperature.unwrap_or(0.7),
+                timeout_seconds: timeout,
+                system: system.unwrap_or_else(|| {
+                    SystemPrompt::String("You are a helpful assistant.".to_string())
+                }),
+                top_p,
+                top_k,
+                tools,
+                tool_choice,
+                reasoning: reasoning.unwrap_or(false),
+                thinking_budget_tokens,
+            }),
+            client: builder.build().expect("Failed to build reqwest Client"),
+        }
+    }
+
+    fn raw_predict_url(&self) -> String {
+        format!(
+            "{}/publishers/anthropic/models/{}:rawPredict",
+            self.config.base_url, self.config.model
+        )
+    }
+
+    fn stream_raw_predict_url(&self) -> String {
+        format!(
+            "{}/publishers/anthropic/models/{}:streamRawPredict",
+            self.config.base_url, self.config.model
+        )
+    }
+
+    fn convert_messages<'a>(messages: &'a [ChatMessage]) -> Vec<VAMessage<'a>> {
+        messages
+            .iter()
+            .map(|m| VAMessage {
+                role: match m.role {
+                    ChatRole::User => "user",
+                    ChatRole::Assistant => "assistant",
+                },
+                content: match &m.message_type {
+                    MessageType::Text => vec![VAContent {
+                        content_type: Some("text"),
+                        text: Some(&m.content),
+                        source: None,
+                        tool_use_id: None,
+                        tool_input: None,
+                        tool_name: None,
+                        tool_result_id: None,
+                        tool_output: None,
+                    }],
+                    MessageType::Image((image_mime, raw_bytes)) => vec![VAContent {
+                        content_type: Some("image"),
+                        text: None,
+                        source: Some(VAImageSource {
+                            source_type: "base64",
+                            media_type: image_mime.mime_type(),
+                            data: BASE64.encode(raw_bytes),
+                        }),
+                        tool_use_id: None,
+                        tool_input: None,
+                        tool_name: None,
+                        tool_result_id: None,
+                        tool_output: None,
+                    }],
+                    MessageType::ToolUse(calls) => calls
+                        .iter()
+                        .map(|c| VAContent {
+                            content_type: Some("tool_use"),
+                            text: None,
+                            source: None,
+                            tool_use_id: Some(c.id.clone()),
+                            tool_input: Some(
+                                serde_json::from_str(&c.function.arguments)
+                                    .unwrap_or(c.function.arguments.clone().into()),
+                            ),
+                            tool_name: Some(c.function.name.clone()),
+                            tool_result_id: None,
+                            tool_output: None,
+                        })
+                        .collect(),
+                    MessageType::ToolResult(responses) => responses
+                        .iter()
+                        .map(|r| VAContent {
+                            content_type: Some("tool_result"),
+                            text: None,
+                            source: None,
+                            tool_use_id: None,
+                            tool_input: None,
+                            tool_name: None,
+                            tool_result_id: Some(r.id.clone()),
+                            tool_output: Some(r.function.arguments.clone()),
+                        })
+                        .collect(),
+                    _ => vec![VAContent {
+                        content_type: Some("text"),
+                        text: Some(&m.content),
+                        source: None,
+                        tool_use_id: None,
+                        tool_input: None,
+                        tool_name: None,
+                        tool_result_id: None,
+                        tool_output: None,
+                    }],
+                },
+            })
+            .collect()
+    }
+
+    fn prepare_tools<'a>(
+        tools: Option<&'a [Tool]>,
+        instance_tools: Option<&'a [Tool]>,
+        tool_choice: &Option<ToolChoice>,
+    ) -> (Option<Vec<VATool<'a>>>, Option<HashMap<String, String>>) {
+        let maybe_tools: Option<&[Tool]> = tools.or(instance_tools);
+        let va_tools = maybe_tools.map(|slice| {
+            slice
+                .iter()
+                .map(|t| VATool {
+                    name: &t.function.name,
+                    description: &t.function.description,
+                    schema: &t.function.parameters,
+                })
+                .collect()
+        });
+        let choice_map = match tool_choice {
+            Some(ToolChoice::Auto) => {
+                Some(HashMap::from([("type".to_string(), "auto".to_string())]))
+            }
+            Some(ToolChoice::Any) => Some(HashMap::from([("type".to_string(), "any".to_string())])),
+            Some(ToolChoice::Tool(name)) => Some(HashMap::from([
+                ("type".to_string(), "tool".to_string()),
+                ("name".to_string(), name.clone()),
+            ])),
+            Some(ToolChoice::None) => {
+                Some(HashMap::from([("type".to_string(), "none".to_string())]))
+            }
+            None => None,
+        };
+        let final_choice = if va_tools.is_some() { choice_map } else { None };
+        (va_tools, final_choice)
+    }
+
+    fn system_prompt_value<'a>(&'a self) -> Option<VASystemPrompt<'a>> {
+        match &self.config.system {
+            SystemPrompt::String(s) if !s.is_empty() => Some(VASystemPrompt::String(s)),
+            SystemPrompt::Messages(msgs) if !msgs.is_empty() => {
+                Some(VASystemPrompt::Messages(msgs))
+            }
+            _ => None,
+        }
+    }
+}
+
+const AUDIO_UNSUPPORTED: &str = "Audio messages are not supported by Vertex AI";
+
+#[async_trait]
+impl ChatProvider for VertexAI {
+    async fn chat_with_tools(
+        &self,
+        messages: &[ChatMessage],
+        tools: Option<&[Tool]>,
+    ) -> Result<Box<dyn ChatResponse>, LLMError> {
+        crate::chat::ensure_no_audio(messages, AUDIO_UNSUPPORTED)?;
+
+        let va_messages = Self::convert_messages(messages);
+        let (va_tools, tool_choice_map) = Self::prepare_tools(
+            tools,
+            self.config.tools.as_deref(),
+            &self.config.tool_choice,
+        );
+
+        let thinking = if self.config.reasoning {
+            Some(VAThinking {
+                thinking_type: "enabled".to_string(),
+                budget_tokens: self.config.thinking_budget_tokens.unwrap_or(16000),
+            })
+        } else {
+            None
+        };
+
+        let req_body = VertexAIRequest {
+            anthropic_version: "vertex-2023-10-16",
+            messages: va_messages,
+            max_tokens: Some(self.config.max_tokens),
+            temperature: Some(self.config.temperature),
+            system: self.system_prompt_value(),
+            stream: Some(false),
+            top_p: self.config.top_p,
+            top_k: self.config.top_k,
+            tools: va_tools,
+            tool_choice: tool_choice_map,
+            thinking,
+        };
+
+        let mut request = self
+            .client
+            .post(self.raw_predict_url())
+            .header("Authorization", format!("Bearer {}", self.config.token))
+            .header("Content-Type", "application/json")
+            .json(&req_body);
+
+        if self.config.timeout_seconds > 0 {
+            request =
+                request.timeout(std::time::Duration::from_secs(self.config.timeout_seconds));
+        }
+
+        log::debug!("VertexAI request: POST {}", self.raw_predict_url());
+        let resp = request.send().await?;
+        log::debug!("VertexAI HTTP status: {}", resp.status());
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(LLMError::ResponseFormatError {
+                message: format!("Vertex AI returned error status: {status}"),
+                raw_response: body,
+            });
+        }
+
+        let body = resp.text().await?;
+        let json_resp: VAResponse = serde_json::from_str(&body)
+            .map_err(|e| LLMError::HttpError(format!("Failed to parse Vertex AI response: {e}")))?;
+        Ok(Box::new(json_resp))
+    }
+
+    async fn chat(&self, messages: &[ChatMessage]) -> Result<Box<dyn ChatResponse>, LLMError> {
+        self.chat_with_tools(messages, None).await
+    }
+
+    async fn chat_stream(
+        &self,
+        messages: &[ChatMessage],
+    ) -> Result<std::pin::Pin<Box<dyn Stream<Item = Result<String, LLMError>> + Send>>, LLMError>
+    {
+        crate::chat::ensure_no_audio(messages, AUDIO_UNSUPPORTED)?;
+
+        let va_messages = Self::convert_messages(messages);
+
+        let req_body = VertexAIRequest {
+            anthropic_version: "vertex-2023-10-16",
+            messages: va_messages,
+            max_tokens: Some(self.config.max_tokens),
+            temperature: Some(self.config.temperature),
+            system: self.system_prompt_value(),
+            stream: Some(true),
+            top_p: self.config.top_p,
+            top_k: self.config.top_k,
+            tools: None,
+            tool_choice: None,
+            thinking: None,
+        };
+
+        let mut request = self
+            .client
+            .post(self.stream_raw_predict_url())
+            .header("Authorization", format!("Bearer {}", self.config.token))
+            .header("Content-Type", "application/json")
+            .json(&req_body);
+
+        if self.config.timeout_seconds > 0 {
+            request =
+                request.timeout(std::time::Duration::from_secs(self.config.timeout_seconds));
+        }
+
+        let response = request.send().await?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await?;
+            return Err(LLMError::ResponseFormatError {
+                message: format!("Vertex AI streaming returned error status: {status}"),
+                raw_response: error_text,
+            });
+        }
+
+        Ok(crate::chat::create_sse_stream(
+            response,
+            crate::backends::anthropic::parse_anthropic_sse_chunk,
+        ))
+    }
+
+    async fn chat_stream_with_tools(
+        &self,
+        messages: &[ChatMessage],
+        tools: Option<&[Tool]>,
+    ) -> Result<std::pin::Pin<Box<dyn Stream<Item = Result<StreamChunk, LLMError>> + Send>>, LLMError>
+    {
+        let va_messages = Self::convert_messages(messages);
+        let (va_tools, tool_choice_map) = Self::prepare_tools(
+            tools,
+            self.config.tools.as_deref(),
+            &self.config.tool_choice,
+        );
+
+        let req_body = VertexAIRequest {
+            anthropic_version: "vertex-2023-10-16",
+            messages: va_messages,
+            max_tokens: Some(self.config.max_tokens),
+            temperature: Some(self.config.temperature),
+            system: self.system_prompt_value(),
+            stream: Some(true),
+            top_p: self.config.top_p,
+            top_k: self.config.top_k,
+            tools: va_tools,
+            tool_choice: tool_choice_map,
+            thinking: None,
+        };
+
+        let mut request = self
+            .client
+            .post(self.stream_raw_predict_url())
+            .header("Authorization", format!("Bearer {}", self.config.token))
+            .header("Content-Type", "application/json")
+            .json(&req_body);
+
+        if self.config.timeout_seconds > 0 {
+            request =
+                request.timeout(std::time::Duration::from_secs(self.config.timeout_seconds));
+        }
+
+        let response = request.send().await?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await?;
+            return Err(LLMError::ResponseFormatError {
+                message: format!("Vertex AI streaming returned error status: {status}"),
+                raw_response: error_text,
+            });
+        }
+
+        Ok(crate::backends::anthropic::create_anthropic_tool_stream(response))
+    }
+}
+
+#[async_trait]
+impl CompletionProvider for VertexAI {
+    async fn complete(&self, _req: &CompletionRequest) -> Result<CompletionResponse, LLMError> {
+        Err(LLMError::ProviderError(
+            "Completion not supported by Vertex AI backend".to_string(),
+        ))
+    }
+}
+
+#[async_trait]
+impl EmbeddingProvider for VertexAI {
+    async fn embed(&self, _text: Vec<String>) -> Result<Vec<Vec<f32>>, LLMError> {
+        Err(LLMError::ProviderError(
+            "Embedding not supported by Vertex AI Anthropic backend".to_string(),
+        ))
+    }
+}
+
+#[async_trait]
+impl SpeechToTextProvider for VertexAI {
+    async fn transcribe(&self, _audio: Vec<u8>) -> Result<String, LLMError> {
+        Err(LLMError::ProviderError(
+            "Speech to text not supported by Vertex AI".to_string(),
+        ))
+    }
+}
+
+#[async_trait]
+impl TextToSpeechProvider for VertexAI {}
+
+#[async_trait]
+impl ModelsProvider for VertexAI {
+    async fn list_models(
+        &self,
+        _request: Option<&ModelListRequest>,
+    ) -> Result<Box<dyn ModelListResponse>, LLMError> {
+        Err(LLMError::ProviderError(
+            "Model listing not supported by Vertex AI backend".to_string(),
+        ))
+    }
+}
+
+impl crate::LLMProvider for VertexAI {
+    fn tools(&self) -> Option<&[Tool]> {
+        self.config.tools.as_deref()
+    }
+}

--- a/src/bin/llm-cli/provider/factory/resolve.rs
+++ b/src/bin/llm-cli/provider/factory/resolve.rs
@@ -125,6 +125,7 @@ fn backend_label(backend: &LLMBackend) -> String {
         LLMBackend::Phind => "phind",
         LLMBackend::ElevenLabs => "elevenlabs",
         LLMBackend::AwsBedrock => "aws-bedrock",
+        LLMBackend::VertexAI => "vertex-ai",
     }
     .to_string()
 }

--- a/src/bin/llm-cli/provider/keys.rs
+++ b/src/bin/llm-cli/provider/keys.rs
@@ -16,6 +16,7 @@ pub fn backend_env_key(backend: &LLMBackend) -> Option<&'static str> {
         LLMBackend::Ollama
         | LLMBackend::Phind
         | LLMBackend::ElevenLabs
-        | LLMBackend::AwsBedrock => None,
+        | LLMBackend::AwsBedrock
+        | LLMBackend::VertexAI => None,
     }
 }

--- a/src/bin/llm-cli/provider/registry.rs
+++ b/src/bin/llm-cli/provider/registry.rs
@@ -82,6 +82,7 @@ fn builtin_provider_list() -> Vec<ProviderInfo> {
         provider_info("huggingface", "HuggingFace", LLMBackend::HuggingFace),
         provider_info("aws-bedrock", "AWS Bedrock", LLMBackend::AwsBedrock),
         provider_info("elevenlabs", "ElevenLabs", LLMBackend::ElevenLabs),
+        provider_info("vertex-ai", "Google Vertex AI", LLMBackend::VertexAI),
     ]
 }
 
@@ -107,6 +108,7 @@ fn provider_capabilities(backend: &LLMBackend) -> ProviderCapabilities {
         | LLMBackend::HuggingFace
         | LLMBackend::Anthropic => ProviderCapabilities::FULL,
         LLMBackend::Google | LLMBackend::AwsBedrock => ProviderCapabilities::TOOLS_NO_STREAM,
+        LLMBackend::VertexAI => ProviderCapabilities::FULL,
         LLMBackend::Ollama => ProviderCapabilities::LOCAL_BASIC,
         LLMBackend::Phind => ProviderCapabilities::STREAM_ONLY,
         LLMBackend::ElevenLabs => ProviderCapabilities::NONE,

--- a/src/builder/backend.rs
+++ b/src/builder/backend.rs
@@ -18,6 +18,7 @@ pub enum LLMBackend {
     OpenRouter,
     HuggingFace,
     AwsBedrock,
+    VertexAI,
 }
 
 impl std::str::FromStr for LLMBackend {
@@ -40,6 +41,7 @@ impl std::str::FromStr for LLMBackend {
             "openrouter" => Ok(LLMBackend::OpenRouter),
             "huggingface" => Ok(LLMBackend::HuggingFace),
             "aws-bedrock" => Ok(LLMBackend::AwsBedrock),
+            "vertex-ai" | "vertexai" => Ok(LLMBackend::VertexAI),
             _ => Err(LLMError::InvalidRequest(format!(
                 "Unknown LLM backend: {s}"
             ))),

--- a/src/builder/build/backends/google.rs
+++ b/src/builder/build/backends/google.rs
@@ -4,14 +4,21 @@ use super::super::helpers;
 use crate::builder::state::BuilderState;
 
 #[cfg(feature = "google")]
+use reqwest;
+
+#[cfg(feature = "google")]
 pub(super) fn build_google(
     state: &mut BuilderState,
     tools: Option<Vec<Tool>>,
 ) -> Result<Box<dyn LLMProvider>, LLMError> {
     let api_key = helpers::require_api_key(state, "Google")?;
     let timeout = helpers::timeout_or_default(state);
+    let vertex_ai_base_url = state.base_url.take();
 
-    let provider = crate::backends::google::Google::new(
+    let provider = crate::backends::google::Google::with_client_and_vertex(
+        reqwest::Client::builder()
+            .build()
+            .expect("Failed to build reqwest Client"),
         api_key,
         state.model.take(),
         state.max_tokens,
@@ -23,6 +30,7 @@ pub(super) fn build_google(
         state.json_schema.take(),
         tools,
         state.google_service_tier.take(),
+        vertex_ai_base_url,
     );
 
     Ok(Box::new(provider))

--- a/src/builder/build/backends/mod.rs
+++ b/src/builder/build/backends/mod.rs
@@ -7,6 +7,7 @@ mod ollama;
 mod openai;
 mod openai_compatible;
 mod phind;
+mod vertex_ai;
 mod xai;
 
 use crate::{
@@ -40,5 +41,6 @@ pub(super) fn build_backend(
         LLMBackend::AzureOpenAI => azure::build_azure_openai(state, tools, tool_choice),
         LLMBackend::ElevenLabs => elevenlabs::build_elevenlabs(state),
         LLMBackend::AwsBedrock => azure::build_bedrock(state, tools, tool_choice),
+        LLMBackend::VertexAI => vertex_ai::build_vertex_ai(state, tools, tool_choice),
     }
 }

--- a/src/builder/build/backends/vertex_ai.rs
+++ b/src/builder/build/backends/vertex_ai.rs
@@ -1,0 +1,54 @@
+use crate::{
+    builder::SystemPrompt,
+    chat::{Tool, ToolChoice},
+    error::LLMError,
+    LLMProvider,
+};
+
+use super::super::helpers;
+use crate::builder::state::BuilderState;
+
+#[cfg(feature = "vertex_ai")]
+pub(super) fn build_vertex_ai(
+    state: &mut BuilderState,
+    tools: Option<Vec<Tool>>,
+    tool_choice: Option<ToolChoice>,
+) -> Result<Box<dyn LLMProvider>, LLMError> {
+    let token = helpers::require_api_key(state, "Vertex AI")?;
+    let base_url = state.base_url.take().ok_or_else(|| {
+        LLMError::InvalidRequest(
+            "No base_url provided for Vertex AI (expected https://{location}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location})".into(),
+        )
+    })?;
+    let timeout = helpers::timeout_or_default(state);
+    let system_prompt = state.system.take().map(SystemPrompt::String);
+
+    let provider = crate::backends::vertex_ai::VertexAI::new(
+        token,
+        base_url,
+        state.model.take(),
+        state.max_tokens,
+        state.temperature,
+        timeout,
+        system_prompt,
+        state.top_p,
+        state.top_k,
+        tools,
+        tool_choice,
+        state.reasoning,
+        state.reasoning_budget_tokens,
+    );
+
+    Ok(Box::new(provider))
+}
+
+#[cfg(not(feature = "vertex_ai"))]
+pub(super) fn build_vertex_ai(
+    _state: &mut BuilderState,
+    _tools: Option<Vec<Tool>>,
+    _tool_choice: Option<ToolChoice>,
+) -> Result<Box<dyn LLMProvider>, LLMError> {
+    Err(LLMError::InvalidRequest(
+        "vertex_ai feature not enabled".to_string(),
+    ))
+}


### PR DESCRIPTION
## Summary
- `Anthropic::chat_with_tools`/`chat_stream`/`chat_stream_with_tools` always sent `temperature` (defaulting to 0.7) and forwarded `top_p`/`top_k` whenever the caller set them, regardless of model.
- Claude's 5-generation models (`claude-sonnet-5`, `claude-opus-5`, `claude-fable-5-1`, `claude-mythos-5-1`) reject those sampling controls with a 400 — they replaced fixed sampling with adaptive thinking. Older models (Haiku 4.5, Sonnet 4.6, etc.) still accept them.
- This broke every request to `claude-sonnet-5` after `app-tgi-core` moved qa/showroom off Bedrock onto the direct Anthropic API (traced in production: `HTTP status client error (400 Bad Request) for url (https://api.anthropic.com/v1/messages)`), since Bedrock's Converse API tolerated these params where the raw Messages API does not.
- Added `model_supports_sampling_params()` and gated `temperature`/`top_p`/`top_k` in all three request-building sites so current-generation models omit them entirely.

## Test plan
- [x] `cargo test --lib backends::anthropic` — 17 passed, including two new tests for `model_supports_sampling_params`
- [x] `cargo build` clean
- [x] Verified against `app-tgi-core`'s full test suite (105 tests) via a temporary local `[patch]` pointing at this branch — all passing, patch removed before this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTqAsuFeSxPZfb5F9BhmB1